### PR TITLE
docs: freeze changelog for v0.2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### English
 
+### 中文
+
+## 0.2.15 - 2026-08-28
+
+### English
+
 - Paginate runtime logs on Logs the same way as request history, newest first
 - Filter the Models catalog by provider and paginate the list
 - Fix WorkBuddy Global model catalogs: use the Global host from account region, accept CLI agent names besides exact `cli`, and surface catalog errors instead of an empty list


### PR DESCRIPTION
## Summary

- Move the v0.2.15 Unreleased notes under `## 0.2.15 - 2026-08-28` after the GitHub Release published.
- Leave Unreleased empty for later main work. Do not rerun `release.yml` for this freeze.

## Test plan

- [x] Only `CHANGELOG.md` changed
- [x] Unreleased English/中文 headings remain for the next patch
- [x] No tokens, auth blobs, raw captures, or host details in the diff