### PR TITLE
docs: freeze changelog for v0.2.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### English
 
+### 中文
+
+## 0.2.21 - 2026-08-30
+
+### English
+
 - Restyle the console on HeroUI v3 default tokens and compound primitives, replacing the ivory overlay, custom 32px chrome, and hand-rolled alerts, search, pagination, and empty states
 - Lock console selection, radii, and type to one language: accent-soft selected chrome, Outfit + IBM Plex Mono, and ink-plus-cyan brand marks instead of mixed blue / white / violet fills
 - Show HeroUI skeletons on first page load and on refresh or filter fetches, instead of a session spinner or leftover dashes


### PR DESCRIPTION
## Summary
- Move the published v0.2.21 notes out of Unreleased after the release workflow could not push to protected main.
- Do not re-run `release.yml`; that would mint the next patch.

## Test plan
- [x] `python3 scripts/release-notes.py validate`
- [x] Confirm GitHub Release v0.2.21 is published and not a draft