### PR TITLE
docs: freeze changelog for v0.2.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### English
 
+### 中文
+
+## 0.2.23 - 2026-08-30
+
+### English
+
 - Keep Signal Cyan on the C tip and scan only; primary buttons, focus, and selection use Charcoal Ink
 
 ### 中文


### PR DESCRIPTION
## Summary
- Move the v0.2.23 Unreleased bullets under `## 0.2.23 - 2026-08-30`.
- Leave Unreleased empty. Do not re-run `release.yml`; the tag is already public.