### PR TITLE
docs: freeze changelog for v0.2.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### English
 
+### 中文
+
+## 0.2.24 - 2026-08-30
+
+### English
+
 - Add opt-in WorkBuddy daily check-in and token keepalive, plus console actions to check in now and refresh credits
 
 ### 中文


### PR DESCRIPTION
## Summary
- Freeze `CHANGELOG.md` Unreleased notes under `## 0.2.24 - 2026-08-30` after the Release workflow published the tag.
- Expected follow-up: the workflow `changelog` job cannot push to protected `main`.

## Test plan
- [x] `python3 scripts/release-notes.py freeze 0.2.24 --date 2026-08-30`
- [ ] Confirm Unreleased is empty after merge