### PR TITLE
docs: center README and list supported providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### English
 
+- Center the README title, language links, and remaining badges, and drop the Docker image badge
 - Point README community discussion at LINUX DO, drop the CI badge, and keep documentation links on files that remain public
 - Stop tracking maintainer design, plan, and provider notes; they stay local through `.gitignore`
 - When the cross-provider model pool is disabled, reject bare model IDs instead of silently routing them to Qoder
@@ -16,6 +17,7 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### 中文
 
+- README 标题、语言切换和剩余徽章居中，并去掉 Docker Image 徽章
 - README 增加 LINUX DO 社区入口，去掉 CI badge，文档链接只保留仍公开发布的文件
 - 不再跟踪维护用的设计、计划和上游调研文档，改由 `.gitignore` 留在本地
 - 关闭跨 Provider 模型池后拒绝 bare model ID，不再静默回落到 Qoder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### English
 
-- Center the README title, language links, and remaining badges, and drop the Docker image badge
+- Rewrite the README opening around Qoder, WorkBuddy, and Trae CN Solo; center the title, badges, and hero; drop the Docker image badge
 - Point README community discussion at LINUX DO, drop the CI badge, and keep documentation links on files that remain public
 - Stop tracking maintainer design, plan, and provider notes; they stay local through `.gitignore`
 - When the cross-provider model pool is disabled, reject bare model IDs instead of silently routing them to Qoder
@@ -17,7 +17,7 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### 中文
 
-- README 标题、语言切换和剩余徽章居中，并去掉 Docker Image 徽章
+- README 开头改为列出 Qoder、WorkBuddy、Trae 国内 Solo，标题、徽章和 Hero 居中，并去掉 Docker Image 徽章
 - README 增加 LINUX DO 社区入口，去掉 CI badge，文档链接只保留仍公开发布的文件
 - 不再跟踪维护用的设计、计划和上游调研文档，改由 `.gitignore` 留在本地
 - 关闭跨 Provider 模型池后拒绝 bare model ID，不再静默回落到 Qoder

--- a/README.md
+++ b/README.md
@@ -2,25 +2,27 @@
 
 # CLI2API
 
-[English](README_EN.md) · [问题反馈](https://github.com/caigee-cmd/cli2api/issues) · [贡献指南](CONTRIBUTING.md) · [LINUX DO](https://linux.do)
+**把你自己的登录态，变成一个本机 OpenAI 兼容 API**
+
+支持 **Qoder 国际版**、**Qoder 国内版**、**WorkBuddy 国际版**、**WorkBuddy 国内版** 和 **Trae 国内版 Solo**。
+
+常驻 worker、多账号调度，Docker 一键启动。
 
 [![License](https://img.shields.io/github/license/caigee-cmd/cli2api)](LICENSE)
 [![LINUX DO](https://img.shields.io/badge/LINUX%20DO-community-ff6a00)](https://linux.do)
 
-<img src="./docs/assets/readme/hero-zh.svg" width="100%" alt="CLI2API — 把你的 Qoder CLI 登录态，变成一个本机运行的 OpenAI 兼容 API">
+<sub>[English](README_EN.md) · [问题反馈](https://github.com/caigee-cmd/cli2api/issues) · [LINUX DO](https://linux.do)</sub>
+
+<img src="./docs/assets/readme/hero-zh.svg" width="100%" alt="CLI2API — 把你自己的登录态，变成一个本机运行的 OpenAI 兼容 API">
 
 </div>
-
-> **自托管多账号聚合网关** —— 把 Qoder 国际版、Qoder 国内版和 WorkBuddy 的自有登录态聚合成一个本机 OpenAI 兼容 API。常驻热 worker、多账号调度与故障切换，Docker 单容器部署，Web 控制台管理。
-
-非官方项目，与 Qoder 无关联、未获官方背书。请只使用你有权使用的账号，并遵守 Qoder 及相关服务条款。
 
 ![CLI2API 支持的登录方式、账号类型、端点和部署形态](docs/assets/overview-card.png)
 
 ## 功能
 
 - **OpenAI 兼容代理**：`/v1/chat/completions`、`/v1/models`，流式/非流式、工具调用、`reasoning_content`
-- **多渠道账号池**：Qoder 国际版 / 国内版 / WorkBuddy，地域隔离、账号固定、并发限制、冷却与同族故障切换
+- **多渠道账号池**：Qoder 国际版 / 国内版、WorkBuddy 国际版 / 国内版、Trae 国内版 Solo；地域隔离、账号固定、并发限制、冷却与同族故障切换
 - **常驻热 worker**：每账号独立 Node 进程与运行目录，鉴权、WASM 编码和云端 SSE 连接保持热；预热后小对话延迟约 1-2 秒，按请求拉起 CLI 的方案通常要 10 秒以上
 - **多种登录方式**：浏览器 Device Flow OAuth、PAT、`qoder-native-v1` 凭证导入/导出
 - **Web 控制台**：账号、模型、接入、请求历史与运行时日志，明暗主题
@@ -29,7 +31,7 @@
 
 ## 快速开始
 
-依赖：Docker（macOS / Windows 用 Docker Desktop，Linux 用 Docker Engine + Compose），以及一个你自己控制的 Qoder 账号。Windows 的 Docker Desktop 必须切换到 Linux containers。
+依赖：Docker（macOS / Windows 用 Docker Desktop，Linux 用 Docker Engine + Compose），以及一个你自己控制的 Qoder、WorkBuddy 或 Trae 账号。Windows 的 Docker Desktop 必须切换到 Linux containers。
 
 ```bash
 git clone https://github.com/caigee-cmd/cli2api.git
@@ -68,7 +70,7 @@ API Key:  <首次启动时生成的 Key>
 
 ## 适合什么场景
 
-- 想在本机或私有服务器上统一接入 Qoder / WorkBuddy
+- 想在本机或私有服务器上统一接入 Qoder / WorkBuddy / Trae
 - 已经在使用 OpenAI API 格式的客户端或脚本
 - 需要在多个账号之间自动路由和故障切换
 - 想保留登录能力，同时避免每个请求启动完整 CLI Agent
@@ -93,7 +95,7 @@ CLI2API 是本地网关：不提供账号、额度或官方 API 服务，不做�
 
 **长期**
 
-- 更多上游渠道（Cursor、Trae CN Solo 等，WorkBuddy 验收后评估）
+- 更多上游渠道（Cursor 等）
 - 可选的提示词 / 回复留档（显式开关，默认关闭）
 
 ## 文档

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
+<div align="center">
+
 # CLI2API
 
 [English](README_EN.md) · [问题反馈](https://github.com/caigee-cmd/cli2api/issues) · [贡献指南](CONTRIBUTING.md) · [LINUX DO](https://linux.do)
 
-[![Docker Image](https://ghcr-badge.egpl.dev/caigee-cmd/cli2api/latest_tag?label=docker&color=blue)](https://github.com/caigee-cmd/cli2api/pkgs/container/cli2api)
 [![License](https://img.shields.io/github/license/caigee-cmd/cli2api)](LICENSE)
 [![LINUX DO](https://img.shields.io/badge/LINUX%20DO-community-ff6a00)](https://linux.do)
 
-<p align="center">
-  <img src="./docs/assets/readme/hero-zh.svg" width="100%" alt="CLI2API — 把你的 Qoder CLI 登录态，变成一个本机运行的 OpenAI 兼容 API">
-</p>
+<img src="./docs/assets/readme/hero-zh.svg" width="100%" alt="CLI2API — 把你的 Qoder CLI 登录态，变成一个本机运行的 OpenAI 兼容 API">
+
+</div>
 
 > **自托管多账号聚合网关** —— 把 Qoder 国际版、Qoder 国内版和 WorkBuddy 的自有登录态聚合成一个本机 OpenAI 兼容 API。常驻热 worker、多账号调度与故障切换，Docker 单容器部署，Web 控制台管理。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -2,25 +2,27 @@
 
 # CLI2API
 
-[中文](README.md) · [Issues](https://github.com/caigee-cmd/cli2api/issues) · [Contributing](CONTRIBUTING.md) · [LINUX DO](https://linux.do)
+**Turn your own logins into a local OpenAI-compatible API**
+
+Supports **Qoder Global**, **Qoder CN**, **WorkBuddy Global**, **WorkBuddy CN**, and **Trae CN Solo**.
+
+Long-lived workers, multi-account scheduling, one-command Docker start.
 
 [![License](https://img.shields.io/github/license/caigee-cmd/cli2api)](LICENSE)
 [![LINUX DO](https://img.shields.io/badge/LINUX%20DO-community-ff6a00)](https://linux.do)
 
-<img src="./docs/assets/readme/hero-en.svg" width="100%" alt="CLI2API — your Qoder CLI login, served as a local OpenAI-compatible API">
+<sub>[中文](README.md) · [Issues](https://github.com/caigee-cmd/cli2api/issues) · [LINUX DO](https://linux.do)</sub>
+
+<img src="./docs/assets/readme/hero-en.svg" width="100%" alt="CLI2API — turn your own logins into a local OpenAI-compatible API">
 
 </div>
-
-> **A self-hosted multi-account gateway** — aggregates your own Qoder Global, Qoder CN, and WorkBuddy logins into one local OpenAI-compatible API. Long-lived warm workers, multi-account scheduling with failover, a single Docker container, and a web console.
-
-Unofficial project, not affiliated with or endorsed by Qoder. Use only accounts you are authorized to use, and follow the terms of Qoder and related services.
 
 ![Supported login methods, account types, endpoints, and deployment targets](docs/assets/overview-card.png)
 
 ## Features
 
 - **OpenAI-compatible proxy**: `/v1/chat/completions`, `/v1/models` — streaming/non-streaming, tool calls, `reasoning_content`
-- **Multi-channel account pool**: Qoder Global / Qoder CN / WorkBuddy with region isolation, account pinning, concurrency limits, cooldowns, and same-family failover
+- **Multi-channel account pool**: Qoder Global / Qoder CN, WorkBuddy Global / WorkBuddy CN, Trae CN Solo — region isolation, account pinning, concurrency limits, cooldowns, and same-family failover
 - **Long-lived warm workers**: one isolated Node process and runtime directory per account keeps authentication, WASM encoding, and cloud SSE connections warm. Typical small-chat latency is ~1-2s after warmup, versus ~10s+ for spawn-per-request wrappers
 - **Multiple login methods**: browser Device Flow OAuth, PAT, and `qoder-native-v1` credential import/export
 - **Web console**: accounts, models, access, request history, and runtime logs, with light and dark themes
@@ -29,7 +31,7 @@ Unofficial project, not affiliated with or endorsed by Qoder. Use only accounts 
 
 ## Quick start
 
-Requirements: Docker (Docker Desktop on macOS/Windows, Docker Engine + Compose on Linux) and a Qoder account you control. On Windows, Docker Desktop must use Linux containers.
+Requirements: Docker (Docker Desktop on macOS/Windows, Docker Engine + Compose on Linux) and a Qoder, WorkBuddy, or Trae account you control. On Windows, Docker Desktop must use Linux containers.
 
 ```bash
 git clone https://github.com/caigee-cmd/cli2api.git
@@ -68,7 +70,7 @@ Accounts, models, access, and logs all live in one web console. Each account sig
 
 ## Use cases
 
-- Connect Qoder / WorkBuddy to local or private-server tooling
+- Connect Qoder / WorkBuddy / Trae to local or private-server tooling
 - Reuse OpenAI-compatible clients and scripts
 - Route requests across multiple accounts with failover
 - Keep login state available without starting a full CLI Agent per request
@@ -93,7 +95,7 @@ CLI2API is a local gateway: it does not provide accounts, quotas, or an official
 
 **Longer term**
 
-- More upstream channels (Cursor, Trae CN Solo, etc.; evaluated after WorkBuddy acceptance)
+- More upstream channels (Cursor, etc.)
 - Optional prompt/completion capture behind an explicit switch (off by default)
 
 ## Documentation

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,14 +1,15 @@
+<div align="center">
+
 # CLI2API
 
 [中文](README.md) · [Issues](https://github.com/caigee-cmd/cli2api/issues) · [Contributing](CONTRIBUTING.md) · [LINUX DO](https://linux.do)
 
-[![Docker Image](https://ghcr-badge.egpl.dev/caigee-cmd/cli2api/latest_tag?label=docker&color=blue)](https://github.com/caigee-cmd/cli2api/pkgs/container/cli2api)
 [![License](https://img.shields.io/github/license/caigee-cmd/cli2api)](LICENSE)
 [![LINUX DO](https://img.shields.io/badge/LINUX%20DO-community-ff6a00)](https://linux.do)
 
-<p align="center">
-  <img src="./docs/assets/readme/hero-en.svg" width="100%" alt="CLI2API — your Qoder CLI login, served as a local OpenAI-compatible API">
-</p>
+<img src="./docs/assets/readme/hero-en.svg" width="100%" alt="CLI2API — your Qoder CLI login, served as a local OpenAI-compatible API">
+
+</div>
 
 > **A self-hosted multi-account gateway** — aggregates your own Qoder Global, Qoder CN, and WorkBuddy logins into one local OpenAI-compatible API. Long-lived warm workers, multi-account scheduling with failover, a single Docker container, and a web console.
 


### PR DESCRIPTION
## Summary
- Center the README title, badges, and hero; drop the Docker image badge.
- Lead with a one-line pitch and the supported account types: Qoder Global / CN, WorkBuddy Global / CN, Trae CN Solo.
- Drop the unofficial-endorsement disclaimer from the opening.

## Test plan
- [ ] Confirm GitHub README header is centered
- [ ] Confirm Docker badge is gone; License and LINUX DO remain
- [ ] Confirm both Chinese and English openings list the same providers