### PR TITLE
fix: apply stored trae/workbuddy model settings via canonical join key

### DIFF
--- a/internal/providers/trae/client.go
+++ b/internal/providers/trae/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -561,13 +562,22 @@ func (c *Client) capsFor(model string) providers.ModelCapabilities {
 	c.mu.Lock()
 	info, ok := c.catalog[model]
 	if !ok {
-		info, ok = c.catalog[strings.ToLower(model)]
+		// Trae config_name is mixed-case; callers may send the console
+		// canonical form (lowercase, _ folded to -). Try both join keys.
+		info, ok = c.catalog[accounts.CanonicalModelID(model)]
 	}
 	c.mu.Unlock()
 	if ok {
 		return info.Capabilities
 	}
 	return providers.ModelCapabilities{}
+}
+
+// settingModelKey mirrors api.modelContextKey so provider settings saved by
+// the console are found again at chat time. Trae config_name is mixed-case and
+// may contain underscores; both sides must canonicalize identically.
+func settingModelKey(model string) string {
+	return accounts.CanonicalModelID(model)
 }
 
 func (c *Client) chatRequest(ctx context.Context, credential Credential, req translate.ChatRequest, accountID string) (*http.Request, error) {
@@ -585,20 +595,16 @@ func (c *Client) chatRequest(ctx context.Context, credential Credential, req tra
 	rewritten := PrepareBody(payload)
 	var obj map[string]any
 	if err := json.Unmarshal(rewritten, &obj); err == nil {
-		caps := c.capsFor(req.Model)
-		if len(caps.ReasoningOptions) == 0 && !caps.MaxMode && accountID != "" {
-			_, _ = c.Models(ctx, accountID)
-			caps = c.capsFor(req.Model)
-		}
 		maxMode := false
 		storedLevel := ""
 		if req.IsMaxMode != nil {
 			maxMode = *req.IsMaxMode
 		}
+		caps := c.capsFor(req.Model)
 		if setter, ok := c.store.(interface {
 			GetProviderModelSetting(context.Context, string, string) (accounts.ProviderModelSetting, error)
 		}); ok {
-			if stored, err := setter.GetProviderModelSetting(ctx, "trae", strings.ToLower(req.Model)); err == nil {
+			if stored, err := setter.GetProviderModelSetting(ctx, "trae", settingModelKey(req.Model)); err == nil {
 				if req.IsMaxMode == nil {
 					maxMode = stored.MaxMode
 				}
@@ -608,10 +614,20 @@ func (c *Client) chatRequest(ctx context.Context, credential Credential, req tra
 			if maxSetter, ok := c.store.(interface {
 				GetProviderModelMaxMode(context.Context, string, string) (bool, error)
 			}); ok {
-				if stored, err := maxSetter.GetProviderModelMaxMode(ctx, "trae", strings.ToLower(req.Model)); err == nil {
+				if stored, err := maxSetter.GetProviderModelMaxMode(ctx, "trae", settingModelKey(req.Model)); err == nil {
 					maxMode = stored
 				}
 			}
+		}
+		// Caps may be empty because the catalog has not been fetched (fresh
+		// process, first request) or the model is unknown. Only the unknown
+		// case is unrecoverable; refresh once before deciding.
+		if len(caps.ReasoningOptions) == 0 && !caps.MaxMode && accountID != "" {
+			_, _ = c.Models(ctx, accountID)
+			caps = c.capsFor(req.Model)
+		}
+		if maxMode && !caps.MaxMode {
+			log.Printf("trae model %q: max mode requested but catalog says unsupported; sending default context window", req.Model)
 		}
 		applySoloChatFields(obj, req, maxMode, storedLevel, caps)
 		if encoded, err := json.Marshal(obj); err == nil {

--- a/internal/providers/trae/client_test.go
+++ b/internal/providers/trae/client_test.go
@@ -17,8 +17,10 @@ import (
 )
 
 type memStore struct {
-	items  map[string][]byte
-	region string
+	items    map[string][]byte
+	region   string
+	settings map[string]accounts.ProviderModelSetting
+	lookups  []string
 }
 
 func (s *memStore) Get(ctx context.Context, id string) (accounts.Account, error) {
@@ -44,6 +46,13 @@ func (s *memStore) SaveCredentialPayload(ctx context.Context, accountID, format 
 }
 func (s *memStore) Observe(ctx context.Context, id, remoteUID, status, lastError, lastKind string) error {
 	return nil
+}
+func (s *memStore) GetProviderModelSetting(ctx context.Context, provider, modelID string) (accounts.ProviderModelSetting, error) {
+	s.lookups = append(s.lookups, provider+"/"+modelID)
+	if s.settings == nil {
+		return accounts.ProviderModelSetting{}, nil
+	}
+	return s.settings[modelID], nil
 }
 
 func newTestClient(t *testing.T, handler http.Handler) (*Client, *memStore) {
@@ -360,6 +369,114 @@ func TestChatRequestMapsOpenAIReasoningAndMaxMode(t *testing.T) {
 	}
 	if _, ok := got["context_length"]; ok {
 		t.Fatalf("qoder context leaked: %v", got)
+	}
+}
+
+// Regression: settings saved by the console are keyed by canonicalModelID
+// (lowercase, _ and space folded to -). The chat-time lookup must use the
+// same form, otherwise max_mode never reaches the upstream payload.
+func TestChatRequestFindsStoredMaxModeByCanonicalKey(t *testing.T) {
+	payload, _ := Credential{AccessToken: "at", RefreshToken: "rt", UID: "u1", Domain: DomainCN, ExpiresAt: 4102444800}.Encode()
+	store := &memStore{
+		items: map[string][]byte{"acc1": payload},
+		// Console saved "deepseek_v4_pro_official" (underscore form).
+		settings: map[string]accounts.ProviderModelSetting{
+			"deepseek-v4-pro-official": {MaxMode: true},
+		},
+	}
+	var got map[string]any
+	modelsServed := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == pathModels {
+			modelsServed = true
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"config_info_list": []map[string]any{{
+					"config_name":           "DeepSeek-V4-Pro-Official",
+					"context_window_tokens": map[string]any{"dev": 200000, "max": 1000000},
+					"display_config":        map[string]any{"display_name": "DeepSeek-V4-Pro 正式版"},
+				}},
+			})
+			return
+		}
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(soloSSE))
+	}))
+	defer server.Close()
+	client := NewClient(store)
+	client.http = server.Client()
+	client.http.Transport = rewriteTransport{server: server.URL, round: server.Client().Transport}
+
+	// No IsMaxMode in the request and no warm catalog: the stored setting
+	// must still turn on max mode, and the cold-catalog refresh must run so
+	// caps say the model supports it.
+	if _, err := client.ChatNonStream(context.Background(), "acc1", translate.ChatRequest{
+		Model: "DeepSeek-V4-Pro-Official",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got["is_max_mode"] != float64(1) {
+		t.Fatalf("stored max mode not applied: %v", got)
+	}
+	if len(store.lookups) == 0 || store.lookups[0] != "trae/deepseek-v4-pro-official" {
+		t.Fatalf("lookup key mismatch: %v", store.lookups)
+	}
+	if !modelsServed {
+		t.Fatal("cold catalog should be refreshed before deciding max mode")
+	}
+}
+
+// When max mode is on but the model has no max-mode capability, the field is
+// dropped and the request still goes out (with a server-side log line).
+func TestChatRequestDropsMaxModeWhenCatalogSaysUnsupported(t *testing.T) {
+	payload, _ := Credential{AccessToken: "at", RefreshToken: "rt", UID: "u1", Domain: DomainCN, ExpiresAt: 4102444800}.Encode()
+	store := &memStore{items: map[string][]byte{"acc1": payload}}
+	var got map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == pathModels {
+			// Model exists but no max window, no max-mode flags.
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"config_info_list": []map[string]any{{
+					"config_name":    "glm-5.2",
+					"display_config": map[string]any{"display_name": "GLM 5.2"},
+				}},
+			})
+			return
+		}
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(soloSSE))
+	}))
+	defer server.Close()
+	client := NewClient(store)
+	client.http = server.Client()
+	client.http.Transport = rewriteTransport{server: server.URL, round: server.Client().Transport}
+	if _, err := client.Models(context.Background(), "acc1"); err != nil {
+		t.Fatal(err)
+	}
+	max := true
+	if _, err := client.ChatNonStream(context.Background(), "acc1", translate.ChatRequest{
+		Model:     "glm-5.2",
+		IsMaxMode: &max,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := got["is_max_mode"]; ok {
+		t.Fatalf("unsupported max mode must not be sent: %v", got)
+	}
+}
+
+func TestSettingModelKeyMatchesConsoleCanonicalForm(t *testing.T) {
+	cases := map[string]string{
+		"DeepSeek-V4-Pro-Official": "deepseek-v4-pro-official",
+		"deepseek_v4_pro_official": "deepseek-v4-pro-official",
+		"GLM 5.3":                  "glm-5.3",
+		"glm-5.2":                  "glm-5.2",
+	}
+	for input, want := range cases {
+		if got := settingModelKey(input); got != want {
+			t.Fatalf("settingModelKey(%q)=%q want %q", input, got, want)
+		}
 	}
 }
 

--- a/internal/providers/workbuddy/catalog.go
+++ b/internal/providers/workbuddy/catalog.go
@@ -3,6 +3,7 @@ package workbuddy
 import (
 	"strings"
 
+	"github.com/caigee-cmd/cli2api/internal/accounts"
 	"github.com/caigee-cmd/cli2api/internal/providers"
 )
 
@@ -89,7 +90,9 @@ func (c *Client) capsFor(model string) providers.ModelCapabilities {
 	c.mu.Lock()
 	info, ok := c.catalog[model]
 	if !ok {
-		info, ok = c.catalog[strings.ToLower(model)]
+		// Public model IDs may arrive underscored or mixed-case; the console
+		// canonical form (lowercase, _ folded to -) is the stable join key.
+		info, ok = c.catalog[accounts.CanonicalModelID(model)]
 	}
 	c.mu.Unlock()
 	if ok {

--- a/internal/providers/workbuddy/client.go
+++ b/internal/providers/workbuddy/client.go
@@ -363,17 +363,19 @@ func (c *Client) chatRequest(ctx context.Context, accountID string, credential C
 		"tool_choice": req.ToolChoice,
 	}
 	caps := c.capsFor(req.Model)
-	if len(caps.ReasoningOptions) == 0 && accountID != "" {
-		_, _ = c.Models(ctx, accountID)
-		caps = c.capsFor(req.Model)
-	}
 	storedLevel := ""
 	if setter, ok := c.store.(interface {
 		GetProviderModelSetting(context.Context, string, string) (accounts.ProviderModelSetting, error)
 	}); ok {
-		if stored, err := setter.GetProviderModelSetting(ctx, "workbuddy", strings.ToLower(req.Model)); err == nil {
+		// settingModelKey must canonicalize exactly like api.modelContextKey
+		// so console-saved reasoning levels are found at chat time.
+		if stored, err := setter.GetProviderModelSetting(ctx, "workbuddy", accounts.CanonicalModelID(req.Model)); err == nil {
 			storedLevel = stored.ReasoningEffort
 		}
+	}
+	if len(caps.ReasoningOptions) == 0 && accountID != "" {
+		_, _ = c.Models(ctx, accountID)
+		caps = c.capsFor(req.Model)
 	}
 	applyChatReasoning(body, req, storedLevel, caps)
 	payload, err := json.Marshal(body)

--- a/internal/providers/workbuddy/client_test.go
+++ b/internal/providers/workbuddy/client_test.go
@@ -20,6 +20,7 @@ type memStore struct {
 	observed   []string
 	lastKind   string
 	lastStatus string
+	settings   map[string]accounts.ProviderModelSetting
 }
 
 func (s *memStore) Get(ctx context.Context, id string) (accounts.Account, error) {
@@ -48,6 +49,12 @@ func (s *memStore) Observe(ctx context.Context, id, remoteUID, status, lastError
 	s.lastStatus = status
 	s.lastKind = lastKind
 	return nil
+}
+func (s *memStore) GetProviderModelSetting(ctx context.Context, provider, modelID string) (accounts.ProviderModelSetting, error) {
+	if s.settings == nil {
+		return accounts.ProviderModelSetting{}, nil
+	}
+	return s.settings[modelID], nil
 }
 
 func newTestClient(t *testing.T, handler http.Handler) (*Client, *memStore) {
@@ -294,6 +301,48 @@ func TestChatRequestSendsCatalogReasoningEffort(t *testing.T) {
 	reasoning, _ := got["reasoning"].(map[string]any)
 	if reasoning["effort"] != "xhigh" {
 		t.Fatalf("reasoning=%v", got["reasoning"])
+	}
+}
+
+// Regression: the console stores provider settings under the canonical model
+// key (lowercase, _ folded to -); chat-time lookups must use the same form.
+func TestChatRequestFindsStoredReasoningByCanonicalKey(t *testing.T) {
+	payload, _ := Credential{AccessToken: "at", UID: "u1", Domain: "codebuddy.cn", ExpiresAt: 4102444800}.Encode()
+	store := &memStore{
+		items: map[string][]byte{"acc1": payload},
+		// Console saved the reasoning level under the canonical key.
+		settings: map[string]accounts.ProviderModelSetting{
+			"glm-5.3": {ReasoningEffort: "xhigh"},
+		},
+	}
+	var got map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == pathModelsCN {
+			_ = json.NewEncoder(w).Encode(map[string]any{"code": 0, "data": map[string]any{
+				"models": []map[string]any{{
+					"id": "glm-5.3", "name": "GLM-5.3", "supportsReasoning": true,
+					"reasoning": map[string]any{"defaultEffort": "high", "supportedEfforts": []string{"low", "high", "xhigh"}},
+				}},
+				"agents": []map[string]any{{"name": "cli", "models": []string{"glm-5.3"}}},
+			}})
+			return
+		}
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(chatSSE))
+	}))
+	defer server.Close()
+	client := NewClient(store)
+	client.http = server.Client()
+	client.http.Transport = rewriteTransport{server: server.URL, round: server.Client().Transport}
+	if _, err := client.ChatNonStream(context.Background(), "acc1", translate.ChatRequest{
+		Model: "GLM_5.3", Messages: []translate.ChatMessage{{Role: "user", Content: "hi"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	reasoning, _ := got["reasoning"].(map[string]any)
+	if reasoning["effort"] != "xhigh" {
+		t.Fatalf("stored reasoning not applied via canonical key: %v", got["reasoning"])
 	}
 }
 


### PR DESCRIPTION
## 问题

控制台(Models 页)保存 trae / workbuddy 的模型设置(max 模式开关、推理档位)后,聊天请求时这些设置**从不生效**:

- 控制台写入用 canonical key(`api.modelContextKey`:小写 + `_`/空格折成 `-`)
- 适配器读取只用 `strings.ToLower(req.Model)`

Trae 的 `config_name` 是混合大小写(如 `DeepSeek-V4-Pro-Official`),带下划线的公开模型 ID 也会让两边 key 对不上 → 存储行查不到,`max_mode` 永远是 false,存的推理档位被忽略。

第二个缺口:`capsFor` 只做精确 + 小写匹配。带下划线的模型 ID(`GLM_5.3`)查不到内存 catalog,caps 为零值 → `is_max_mode` 被 `applySoloChatFields` 静默丢弃,无任何日志。

## 修复

1. **统一 join key**:trae / workbuddy 两个适配器的设置查找都改用 `accounts.CanonicalModelID`,与控制台写入同 key。
2. **capsFor canonical 回退**:两个 provider 的 `capsFor` 都加 canonical 形态回退查找,下划线/混合大小写模型 ID 不再丢失 capabilities。
3. **trae 时序修正**:`chatRequest` 先读存储设置、再决定是否拉 catalog(原来 caps 为空就先拉,冷启动时依赖 catalog 先加载;现在存储的 max mode 在冷 catalog 场景也能生效,catalog 刷新会照常执行)。
4. **可观测性**:max mode 被请求但 catalog 显示不支持时打日志,不再无声丢弃。

## 测试

- `TestChatRequestFindsStoredMaxModeByCanonicalKey`(trae):下划线 key 命中 + 冷 catalog 刷新 + `is_max_mode=1` 发出
- `TestChatRequestDropsMaxModeWhenCatalogSaysUnsupported`(trae):不支持的模型正确丢弃该字段
- `TestSettingModelKeyMatchesConsoleCanonicalForm`(trae):key 映射表
- `TestChatRequestFindsStoredReasoningByCanonicalKey`(workbuddy):`GLM_5.3` → `glm-5.3` 命中存储档位(此测试在修 capsFor 前失败,证明 WorkBuddy 有同样缺口)

`go test ./...` 11 包全绿,`go vet` / `gofmt` 干净。

## 说明

Trae 上游协议本来就不接收 `context_length` / `max_input_tokens` 数字(`applySoloChatFields` 显式删除这两个 key),上下文上限由服务端按 `is_max_mode` 决定。本 PR 修的是"开关没传过去";开关生效后才能用到 max 窗口。