### PR TITLE
docs: freeze changelog for v0.2.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### English
 
+### 中文
+
+## 0.2.27 - 2026-08-31
+
+### English
+
 - Fix Trae and WorkBuddy per-model settings (max mode, reasoning effort) never taking effect: the console stores them under the canonical model key while chat requests looked them up with a plain lowercase match, so mixed-case Trae model IDs and underscored public IDs missed the saved row; lookups now share one canonical key, cold-catalog refreshes no longer drop max mode, and a requested-but-unsupported max mode is logged instead of silently dropped
 
 ### 中文


### PR DESCRIPTION
Manual changelog freeze for v0.2.27.

The Release workflow's last job (`changelog: Freeze published changelog`) pushes `docs: freeze changelog for v0.2.27` straight to `main`, but `main` is protected ("Changes must be made through a pull request"), so the push was rejected — the same failure as the previous v0.2.26 run. Everything else in the release (prepare/assets/draft/image/promote/publish/aliases) succeeded and v0.2.27 is published.

This PR does by hand what that job meant to do:

- `python3 scripts/release-notes.py freeze 0.2.27 --date 2026-08-31` — moves the Unreleased bilingual notes into `## 0.2.27 - 2026-08-31` and leaves Unreleased empty
- Same script and flags the workflow uses (`scripts/release-notes.py freeze`), so the result is byte-identical to the intended automation

Follow-up (not in this PR): either give the workflow's bot a bypass path for this push or change the job to open a PR, so the next patch release doesn't fail at the last step.