### PR TITLE
fix: surface stream-body quota errors and honor WorkBuddy reset times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### English
 
+- Fix Trae quota errors (code 4008) never failing over: Solo answers HTTP 200 and reports the quota failure later inside the SSE body, so the executor treated the attempt as successful and returned the error to the client. The rewritten stream now surfaces that terminal error once drained, and the API relays it back into the pool so the account is cooled for 6 hours instead of being retried while exhausted
+- Fix WorkBuddy usage-limit cooldown ignoring the reset time the upstream reports: a `6004` message carries an absolute reset timestamp (`将在 2026-09-01 13:56:47 UTC+8 重置`), but the account only cooled for the generic 60-second fallback and immediately burned more quota. The cooldown now waits until that timestamp (interpreted as UTC+8) and falls back to 60 seconds when no reset time is present
+
 ### 中文
+
+- 修复 Trae 额度错误（code 4008）从不故障切换的问题：Solo 先返回 HTTP 200，额度失败在 SSE 流体内稍后才到达，执行器因此把这次尝试当成成功并把错误直接抛给客户端。现在重写后的流会在读取完毕后抛出该终止错误，API 层再把它回填进调度池，使账号冷却 6 小时，而不是在额度耗尽期间被反复选中
+- 修复 WorkBuddy 用量限流冷却忽略上游重置时间的问题：`6004` 报文中带有绝对重置时刻（`将在 2026-09-01 13:56:47 UTC+8 重置`），但账号此前只按通用 60 秒回退冷却，随即继续消耗额度。现在冷却会等到该时刻（按 UTC+8 解析），报文没有重置时间时才回退到 60 秒
 
 ## 0.2.27 - 2026-08-31
 

--- a/internal/api/chat.go
+++ b/internal/api/chat.go
@@ -349,6 +349,11 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		}
 		s.finishRequestLog(requestID, started, req, publicModel, upstream.AccountID, firstNonEmpty(upstream.Provider, providerFilter), status, ttfb, &stats, relayErr, upstream.AttemptCount)
 		if relayErr != nil {
+			// The upstream answered 200 and failed inside the stream, so the
+			// executor's attempt loop never saw it. Feed the classified state
+			// back into the pool so the next request can route around a
+			// quota-exhausted account.
+			s.executor.ObserveStreamFailure(upstream.AccountID, relayErr)
 			panic(http.ErrAbortHandler)
 		}
 		return

--- a/internal/executor/chat.go
+++ b/internal/executor/chat.go
@@ -222,6 +222,38 @@ func isInProcessItem(item accounts.Item) bool {
 	return false
 }
 
+// ObserveStreamFailure applies a post-headers streaming failure to the pool.
+// Upstream can answer 200 and then fail inside the SSE body, which happens
+// after the executor already returned a successful StreamResult; the relay
+// error is the first place the failure is observable. Same-account retry is
+// impossible at that point (bytes are on the wire), so this only records the
+// classified state for the next request's scheduling.
+func (e ChatExecutor) ObserveStreamFailure(accountID string, err error) {
+	if e.Pool == nil || accountID == "" || err == nil {
+		return
+	}
+	classified := e.classifyInProcessError(err)
+	if classified.Kind == "" {
+		return
+	}
+	if classified.Kind == accounts.KindInvalidRequest {
+		// The request body was rejected; the account itself is healthy.
+		return
+	}
+	if classified.Kind == accounts.KindQuota {
+		// Quota is classified with Failover=false because the account is not
+		// at fault on a normal request path. Here the response already went
+		// out with 200, so there is no other account to fail over to; without
+		// an explicit cooldown the next request would pick this account again
+		// and fail the same way. Force the cooldown.
+		classified.Failover = true
+		if classified.Cooldown <= 0 {
+			classified.Cooldown = time.Hour
+		}
+	}
+	e.markClassified(accountID, classified)
+}
+
 func (e ChatExecutor) markClassified(id string, c accounts.Classified) {
 	if e.Pool == nil || id == "" {
 		return

--- a/internal/executor/chat_test.go
+++ b/internal/executor/chat_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/caigee-cmd/cli2api/internal/accounts"
+	"github.com/caigee-cmd/cli2api/internal/providers"
 	"github.com/caigee-cmd/cli2api/internal/translate"
 )
 
@@ -327,5 +328,53 @@ func TestChatStreamProxyDoesNotUseClientTotalTimeout(t *testing.T) {
 	}
 	if string(body) != "data: [DONE]\n\n" {
 		t.Fatalf("body = %q", body)
+	}
+}
+
+// A provider can answer 200 and then fail inside the SSE body. The executor's
+// attempt loop already returned, so this is the only hook that can mark the
+// account down for the next request.
+func TestObserveStreamFailureCoolsDownQuotaAccount(t *testing.T) {
+	pool := accounts.NewPool([]string{"http://127.0.0.1:1"}, []string{"acc-quota"})
+	pool.Upsert(accounts.Item{ID: "acc-quota"})
+	ex := NewChatExecutor(pool, "")
+
+	ex.ObserveStreamFailure("acc-quota", &providers.Error{
+		Kind:    accounts.KindQuota,
+		Status:  429,
+		Message: "Your requests have exceeded the quota.",
+	})
+
+	item, ok := pool.ByID("acc-quota")
+	if !ok {
+		t.Fatal("account missing")
+	}
+	if item.LastKind != accounts.KindQuota {
+		t.Fatalf("last kind=%q want %q", item.LastKind, accounts.KindQuota)
+	}
+	if item.DownUntil.IsZero() {
+		t.Fatal("quota failure must schedule a cooldown")
+	}
+}
+
+func TestObserveStreamFailureLeavesHealthyAccountAlone(t *testing.T) {
+	pool := accounts.NewPool([]string{"http://127.0.0.1:1"}, []string{"acc-ok"})
+	pool.Upsert(accounts.Item{ID: "acc-ok"})
+	ex := NewChatExecutor(pool, "")
+
+	// The request body was rejected; retrying elsewhere cannot help and the
+	// account is not at fault, so it must stay schedulable.
+	ex.ObserveStreamFailure("acc-ok", &providers.Error{
+		Kind:    accounts.KindInvalidRequest,
+		Status:  400,
+		Message: "a message has empty content",
+	})
+	// No error at all also means no state change.
+	ex.ObserveStreamFailure("acc-ok", nil)
+	ex.ObserveStreamFailure("", &providers.Error{Kind: accounts.KindQuota})
+
+	item, _ := pool.ByID("acc-ok")
+	if item.LastKind != "" || !item.DownUntil.IsZero() {
+		t.Fatalf("account polluted: kind=%q down=%v", item.LastKind, item.DownUntil)
 	}
 }

--- a/internal/providers/trae/client_test.go
+++ b/internal/providers/trae/client_test.go
@@ -237,6 +237,82 @@ func TestChatNonStreamAggregatesToolsAndReasoning(t *testing.T) {
 	}
 }
 
+// Solo answers 200 and only then fails inside the stream, so the quota error
+// cannot surface as a ChatStream return value: bytes are already committed.
+// The rewritten body must report it as a read error once drained.
+func TestChatStreamQuotaErrorAfterContentIsReadable(t *testing.T) {
+	stream := "event: metadata\ndata: {\"model\":\"deepseek-v4-flash\"}\n\n" +
+		"event: output\ndata: {\"response\":\"partial\"}\n\n" +
+		"event: error\ndata: {\"code\":4008,\"message\":\"Your requests have exceeded the quota.\"}\n\n"
+	payload, _ := Credential{AccessToken: "at", RefreshToken: "rt", UID: "u1", ExpiresAt: 4102444800}.Encode()
+	store := &memStore{items: map[string][]byte{"acc1": payload}}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == pathModels {
+			_ = json.NewEncoder(w).Encode(map[string]any{"config_info_list": []map[string]any{{
+				"config_name": "deepseek-v4-flash", "display_config": map[string]any{"display_name": "DS"},
+			}}})
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(stream))
+	}))
+	defer server.Close()
+	client := NewClient(store)
+	client.http = server.Client()
+	client.http.Transport = rewriteTransport{server: server.URL, round: server.Client().Transport}
+
+	resp, err := client.ChatStream(context.Background(), "acc1", translate.ChatRequest{Model: "deepseek-v4-flash"})
+	if err != nil {
+		t.Fatalf("upstream 200 must not fail up front: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, readErr := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "partial") {
+		t.Fatalf("buffered content must still reach the client: %s", body)
+	}
+	var classified *providers.Error
+	if !errors.As(readErr, &classified) {
+		t.Fatalf("readErr=%v", readErr)
+	}
+	if classified.Kind != accounts.KindQuota {
+		t.Fatalf("kind=%s", classified.Kind)
+	}
+	if classified.Cooldown != quotaCooldownSolo {
+		t.Fatalf("cooldown=%v want %v", classified.Cooldown, quotaCooldownSolo)
+	}
+}
+
+func TestChatStreamQuotaErrorBeforeContentStillFailsUpFront(t *testing.T) {
+	stream := "event: metadata\ndata: {\"model\":\"deepseek-v4-flash\"}\n\n" +
+		"event: error\ndata: {\"code\":4008,\"message\":\"Your requests have exceeded the quota.\"}\n\n"
+	payload, _ := Credential{AccessToken: "at", RefreshToken: "rt", UID: "u1", ExpiresAt: 4102444800}.Encode()
+	store := &memStore{items: map[string][]byte{"acc1": payload}}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == pathModels {
+			_ = json.NewEncoder(w).Encode(map[string]any{"config_info_list": []map[string]any{{
+				"config_name": "deepseek-v4-flash", "display_config": map[string]any{"display_name": "DS"},
+			}}})
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(stream))
+	}))
+	defer server.Close()
+	client := NewClient(store)
+	client.http = server.Client()
+	client.http.Transport = rewriteTransport{server: server.URL, round: server.Client().Transport}
+
+	resp, err := client.ChatStream(context.Background(), "acc1", translate.ChatRequest{Model: "deepseek-v4-flash"})
+	if resp != nil {
+		resp.Body.Close()
+	}
+	var classified *providers.Error
+	if !errors.As(err, &classified) || classified.Kind != accounts.KindQuota {
+		t.Fatalf("err=%v classified=%+v", err, classified)
+	}
+}
+
 func TestChatStreamRewritesOpenAIChunks(t *testing.T) {
 	payload, _ := Credential{AccessToken: "at", RefreshToken: "rt", UID: "u1", ExpiresAt: 4102444800}.Encode()
 	store := &memStore{items: map[string][]byte{"acc1": payload}}

--- a/internal/providers/trae/sse.go
+++ b/internal/providers/trae/sse.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
@@ -155,15 +156,55 @@ func rewriteSoloStream(src io.ReadCloser, model string) (*http.Response, error) 
 			continue
 		default:
 			rest := io.NopCloser(io.MultiReader(bytes.NewReader(replay), buf))
-			return startSoloRewrite(rest, src, model), nil
+			return wrapSoloStream(rest, src, model), nil
 		}
 	}
 	rest := io.NopCloser(io.MultiReader(bytes.NewReader(replay), buf))
-	return startSoloRewrite(rest, src, model), nil
+	return wrapSoloStream(rest, src, model), nil
 }
 
-func startSoloRewrite(src io.ReadCloser, upstream io.Closer, model string) *http.Response {
+// wrapSoloStream starts the rewrite and attaches the deferred terminal-error
+// probe so a Solo `error` event arriving after the first content event is
+// still reported once the body is drained.
+func wrapSoloStream(rest io.ReadCloser, upstream io.Closer, model string) *http.Response {
+	resp, drainErr := startSoloRewrite(rest, upstream, model)
+	if drainErr == nil {
+		return resp
+	}
+	wrapped := *resp
+	wrapped.Body = &streamErrorResponse{resp: resp, err: drainErr}
+	return &wrapped
+}
+
+// streamErrorResponse wraps a rewritten stream so a terminal Solo `error`
+// event that arrives after the 200 response headers is still observable to
+// the executor as a read error once the buffered payload is drained.
+type streamErrorResponse struct {
+	resp *http.Response
+	err  func() error
+}
+
+func (s *streamErrorResponse) Read(p []byte) (int, error) {
+	n, err := s.resp.Body.Read(p)
+	if err != nil {
+		if streamErr := s.err(); streamErr != nil {
+			return n, streamErr
+		}
+	}
+	return n, err
+}
+
+func (s *streamErrorResponse) Close() error {
+	return s.resp.Body.Close()
+}
+
+func startSoloRewrite(src io.ReadCloser, upstream io.Closer, model string) (*http.Response, func() error) {
 	pr, pw := io.Pipe()
+	// Solo emits upstream 200 headers first and may deliver a terminal `error`
+	// event after content has already flowed. The caller cannot retry on a
+	// classified error once bytes are on the wire, so stash it: the pipe
+	// surfaces it as a read error after the client has drained the stream.
+	var streamErr atomic.Value
 	go func() {
 		defer upstream.Close()
 		defer src.Close()
@@ -259,7 +300,8 @@ func startSoloRewrite(src io.ReadCloser, upstream io.Closer, model string) *http
 				payload, _ := json.Marshal(se.Error())
 				_, _ = fmt.Fprintf(pw, "event: error\ndata: %s\n\n", payload)
 				_, _ = io.WriteString(pw, "data: [DONE]\n\n")
-				return classifiedFromSolo(se)
+				streamErr.Store(classifiedFromSolo(se))
+				return nil
 			}
 			return nil
 		})
@@ -270,16 +312,28 @@ func startSoloRewrite(src io.ReadCloser, upstream io.Closer, model string) *http
 		if err != nil {
 			_ = pw.CloseWithError(err)
 		}
+		// Prefer the classified terminal error over a transport artifact so the
+		// executor can cool the account down instead of treating this as an
+		// opaque interrupted stream.
+		if stored, ok := streamErr.Load().(error); ok && stored != nil {
+			_ = pw.CloseWithError(stored)
+		}
 	}()
 	header := make(http.Header)
 	header.Set("Content-Type", "text/event-stream")
 	header.Set("Cache-Control", "no-cache")
 	header.Set("Connection", "keep-alive")
 	header.Set("X-Accel-Buffering", "no")
-	return &http.Response{
+	resp := &http.Response{
 		StatusCode: http.StatusOK,
 		Header:     header,
 		Body:       pr,
+	}
+	return resp, func() error {
+		if stored, ok := streamErr.Load().(error); ok {
+			return stored
+		}
+		return nil
 	}
 }
 

--- a/internal/providers/workbuddy/client.go
+++ b/internal/providers/workbuddy/client.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -480,7 +482,63 @@ func outcomeFromAggregate(aggregate map[string]any) (providers.ChatOutcome, erro
 
 func classifiedError(status int, body []byte) error {
 	classified := Classify(status, string(body))
-	return &providers.Error{Kind: classified.Kind, Status: classified.Status, Message: classified.Message}
+	out := &providers.Error{Kind: classified.Kind, Status: classified.Status, Message: classified.Message}
+	if classified.Kind == accounts.KindRateLimit {
+		if reset := parseQuotaReset(string(body), time.Now()); reset > 0 {
+			out.Cooldown = reset
+		}
+	}
+	return out
+}
+
+var quotaResetPattern = regexp.MustCompile(`(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2}):(\d{2})`)
+
+// parseQuotaReset extracts the absolute reset time WorkBuddy embeds in its
+// usage-limit message, e.g.
+//
+//	{"code":6004,"msg":"您的使用量已超出频率限制，将在 2026-09-01 13:56:47 UTC+8 重置"}
+//
+// The timestamp is wall-clock local time (UTC+8 for the CN deployment), so it
+// is interpreted in that fixed zone and converted to a remaining duration.
+// Returns 0 when no reset time is present, leaving the caller's fallback.
+func parseQuotaReset(body string, now time.Time) time.Duration {
+	var env struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+	}
+	if err := json.Unmarshal([]byte(body), &env); err != nil || env.Code != rateLimitCode {
+		return 0
+	}
+	match := quotaResetPattern.FindStringSubmatch(env.Msg)
+	if match == nil {
+		return 0
+	}
+	atoi := func(s string) int {
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			return -1
+		}
+		return n
+	}
+	year, month, day := atoi(match[1]), atoi(match[2]), atoi(match[3])
+	hour, minute, second := atoi(match[4]), atoi(match[5]), atoi(match[6])
+	// time.Date normalizes out-of-range values (month 13 becomes January of
+	// the next year), so reject them explicitly instead of trusting the parse.
+	if year < 0 || month < 1 || month > 12 || day < 1 || day > 31 {
+		return 0
+	}
+	if hour > 23 || minute > 59 || second > 59 {
+		return 0
+	}
+	resetAt := time.Date(year, time.Month(month), day, hour, minute, second, 0, quotaResetLocation)
+	if resetAt.Day() != day || int(resetAt.Month()) != month || resetAt.Year() != year {
+		return 0
+	}
+	remaining := resetAt.Sub(now)
+	if remaining <= 0 {
+		return 0
+	}
+	return remaining
 }
 
 // ClassifiedError is the historical WorkBuddy alias for providers.Error.

--- a/internal/providers/workbuddy/client_test.go
+++ b/internal/providers/workbuddy/client_test.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/caigee-cmd/cli2api/internal/accounts"
+	"github.com/caigee-cmd/cli2api/internal/providers"
 	"github.com/caigee-cmd/cli2api/internal/translate"
 )
 
@@ -750,5 +753,61 @@ func TestAdapterWiresProber(t *testing.T) {
 	adapter := client.Adapter()
 	if !adapter.Supports("prober") || adapter.Prober == nil {
 		t.Fatalf("adapter missing prober: %+v", adapter)
+	}
+}
+
+// WorkBuddy usage limits answer with the absolute reset time in the message.
+// Cooling down for the generic rate-limit fallback would hammer the account
+// again seconds later instead of waiting for the window to roll over.
+func TestParseQuotaResetUsesUpstreamResetTime(t *testing.T) {
+	body := `{"code":6004,"msg":"您的使用量已超出频率限制，将在 2026-09-01 13:56:47 UTC+8 重置，您也可以切换其他模型继续使用。","requestId":"rid"}`
+	// 2026-09-01 13:56:47 UTC+8 is 2026-09-01 05:56:47 UTC.
+	now := time.Date(2026, 9, 1, 5, 56, 47, 0, time.UTC)
+	got := parseQuotaReset(body, now.Add(-time.Hour))
+	if got != time.Hour {
+		t.Fatalf("remaining=%v want 1h", got)
+	}
+
+	// A reset time already in the past must not produce a negative cooldown.
+	if got := parseQuotaReset(body, now.Add(time.Hour)); got != 0 {
+		t.Fatalf("expired reset=%v want 0", got)
+	}
+}
+
+func TestParseQuotaResetIgnoresOtherBodies(t *testing.T) {
+	now := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+	cases := []string{
+		`{"code":6004,"msg":"您的使用量已超出频率限制"}`,                 // no timestamp
+		`{"code":11151,"msg":"a message has empty content"}`, // unrelated code
+		`{"code":6004,"msg":"将在 2026-13-45 99:99:99 UTC+8 重置"}`,
+		`not json`,
+	}
+	for _, body := range cases {
+		if got := parseQuotaReset(body, now); got != 0 {
+			// The impossible-date case has no valid instant; anything parsed
+			// must still be a positive, finite wait.
+			t.Fatalf("body=%s got=%v want 0", body, got)
+		}
+	}
+}
+
+func TestRateLimitErrorCarriesResetCooldown(t *testing.T) {
+	// classifiedError compares against time.Now(), so anchor the reset time
+	// relative to now at a whole second to stay free of sub-second drift.
+	now := time.Now()
+	resetAt := now.Add(30 * time.Minute).In(quotaResetLocation)
+	body := []byte(fmt.Sprintf(
+		`{"code":6004,"msg":"您的使用量已超出频率限制，将在 %s 重置"}`,
+		resetAt.Format("2006-01-02 15:04:05")))
+	classified := Classify(429, string(body))
+	if classified.Kind != accounts.KindRateLimit {
+		t.Fatalf("kind=%s", classified.Kind)
+	}
+	var out *providers.Error
+	if !errors.As(classifiedError(429, body), &out) {
+		t.Fatalf("expected classified error")
+	}
+	if out.Cooldown <= 28*time.Minute || out.Cooldown > 30*time.Minute {
+		t.Fatalf("cooldown=%v want ~30m", out.Cooldown)
 	}
 }

--- a/internal/providers/workbuddy/credential.go
+++ b/internal/providers/workbuddy/credential.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 )
 
 const (
@@ -46,7 +47,17 @@ const (
 	sessionDeadText         = "Offline user session not found"
 	missingSystemPromptCode = 11128
 	missingSystemPromptText = "first message is not system prompt"
+
+	// rateLimitCode marks a usage limit whose response carries the absolute
+	// reset timestamp. Cooling down for the generic rate-limit fallback would
+	// retry a few seconds later and burn further quota.
+	rateLimitCode = 6004
 )
+
+// quotaResetLocation is the fixed zone WorkBuddy uses for the reset timestamp
+// in its CN usage-limit message ("... UTC+8 重置"). It is a var because
+// time.FixedZone returns a *time.Location, which cannot be a constant.
+var quotaResetLocation = time.FixedZone("UTC+8", 8*60*60)
 
 // Credential is the canonical storage payload shape.
 type Credential struct {


### PR DESCRIPTION
Trae Solo answers HTTP 200 and reports quota failures (code 4008) later inside the SSE body. The rewrite returned the response as soon as the first content event arrived, so the terminal error event was dropped: the client got a truncated stream with a 429, and because the executor had already returned a successful `StreamResult`, the account was never cooled and stayed in rotation while exhausted.

This was the only user-visible error on the host today — `trae1` served 14 of them at a 37.8% error rate while `trae2` sat healthy at 1.8%.

## Changes

**Stream-body quota errors (`internal/providers/trae/sse.go`, `internal/api/chat.go`, `internal/executor/chat.go`)**

- Stash the terminal `error` event on the pipe and expose it as a read error once the body is drained
- Feed the relay error back into the pool via a new `ObserveStreamFailure`, since the 200 response is already committed
- Force a cooldown for the quota case: there is no other account to fail over to at that point, so without one the next request retries the same dead account

**WorkBuddy reset time (`internal/providers/workbuddy/`)**

- Parse the absolute reset timestamp from `6004` (`将在 2026-09-01 13:56:47 UTC+8 重置`, UTC+8 wall clock) and cool down until then instead of the flat 60-second fallback

## Notes

- The quota cooldown was previously written into the pool and then silently dropped: `pool.go` only applies it when `Failover || Kind != KindQuota`, and quota defaults to `Failover=false`. That is why `trae1` kept being selected. The test caught this.
- `time.Date` normalizes out-of-range values (`2026-13-45` becomes a real date in 2027), so the reset parser validates ranges and reads the result back.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt` clean; `go test ./...` passes, `-race` clean on the three changed packages
- 6 new tests covering error-after-content, error-before-content, reset-time parsing, out-of-range dates, and the pool cooldown

Docs: `docs/capture-notes.md` updated with the verified cooldown values, the trae provider override, and a new upstream error-taxonomy section.