### PR TITLE
feat: rework account scheduling, cooldown persistence, and backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### English
 
+- Fix uneven load across accounts: rotation used a numeric index into a candidate list that shrinks whenever a retry excludes an account or one enters cooldown, which silently re-seated the rotation and left some accounts nearly idle while others absorbed most traffic. Rotation now resumes from the previously picked account's ID, so it stays even as the candidate set changes
+- Enforce the per-account concurrency limit: `max_inflight` was stored and shown in the console but never read, so a single account could absorb every concurrent request during a burst. Saturated accounts are now skipped in favour of ones with spare capacity
+- Persist cooldowns to SQLite and restore them on start: cooldowns lived only in memory, so every managed update (they run daily) wiped them and let a just-quarantined account walk straight back into rotation
+- Make the account priority field actually schedule traffic: it is now a weight (1–100) driving smooth weighted round-robin. Accounts at the default 50 keep plain round-robin, so existing setups behave exactly as before
+- Cool down only the affected model: a rate limit or quota error on one model no longer takes the whole account offline for every other model
+- Back off on repeated failures: an account failing repeatedly with the same error now cools down progressively longer instead of retrying at a fixed interval, up to 6 hours, and resets as soon as it succeeds
+- Keep a route on one region: when no region is pinned, scheduling reuses the region it last served from instead of letting rotation decide, so a mixed-region pool no longer flips between regions
+
+### 中文
+
+- 修复账号间负载不均的问题：轮转此前用数值索引指向一个会收缩的候选列表（重试排除、账号冷却都会让它变小），这会静默重定位轮转位置，导致部分账号几乎空闲而另一些承担大部分流量。现在轮转从上次选中账号的 ID 继续，候选集变化时分布依然均匀
+- 账号并发上限真正生效：`max_inflight` 此前只存储并在控制台展示，从未参与选号，突发流量下单个账号会吞掉全部并发请求。现在达到上限的账号会被跳过，优先调度有余量的账号
+- 冷却持久化到 SQLite 并在启动时恢复：冷却此前仅存于内存，每次自动更新（每天执行）都会清空，刚被隔离的账号会立刻回到轮转中
+- 账号优先级字段真正参与调度：现在作为权重（1–100）驱动平滑加权轮转。保持默认 50 的账号行为与之前完全一致
+- 只冷却受影响的模型：单个模型限流或额度耗尽不再让整个账号对其他模型下线
+- 重复失败时逐步退避：同一账号反复出现同类错误时，冷却时间会逐步延长（上限 6 小时），成功后立即归零
+- 路由保持在同一个 region：未固定 region 时沿用上次服务的 region，而不是由轮转位置决定，混合 region 的账号池不再来回切换
+
+## 0.2.28 - 2026-08-31
+
+### English
+
 - Fix Trae quota errors (code 4008) never failing over: Solo answers HTTP 200 and reports the quota failure later inside the SSE body, so the executor treated the attempt as successful and returned the error to the client. The rewritten stream now surfaces that terminal error once drained, and the API relays it back into the pool so the account is cooled for 6 hours instead of being retried while exhausted
 - Fix WorkBuddy usage-limit cooldown ignoring the reset time the upstream reports: a `6004` message carries an absolute reset timestamp (`将在 2026-09-01 13:56:47 UTC+8 重置`), but the account only cooled for the generic 60-second fallback and immediately burned more quota. The cooldown now waits until that timestamp (interpreted as UTC+8) and falls back to 60 seconds when no reset time is present
 

--- a/internal/accounts/classify.go
+++ b/internal/accounts/classify.go
@@ -28,6 +28,39 @@ type Classified struct {
 	Type       string
 	Message    string
 	RetryAfter time.Duration
+	// Model scopes the cooldown to one public model. When set, only that
+	// model is cooled; the account keeps serving everything else.
+	Model string
+}
+
+// backoffFloor and backoffCeiling bound the exponential backoff applied to
+// repeated failures of the same kind. A first failure still uses the
+// classifier's own duration; backoff only extends it on repeats.
+const (
+	backoffFloor    = 30 * time.Second
+	backoffCeiling  = 6 * time.Hour
+	backoffMaxLevel = 8
+)
+
+// nextBackoffCooldown lengthens the cooldown for a repeatedly failing account.
+// level is the count of consecutive failures of this kind; the returned level
+// is the value to store for the next failure. Success resets it to zero.
+func nextBackoffCooldown(base time.Duration, level int) (time.Duration, int) {
+	if level < 0 {
+		level = 0
+	}
+	if level >= backoffMaxLevel {
+		return backoffCeiling, level
+	}
+	multiplier := time.Duration(1) << level
+	next := base * multiplier
+	if next < backoffFloor {
+		next = backoffFloor
+	}
+	if next >= backoffCeiling {
+		return backoffCeiling, level
+	}
+	return next, level + 1
 }
 
 func ParseRetryAfter(raw string, fallback time.Duration) time.Duration {

--- a/internal/accounts/manager.go
+++ b/internal/accounts/manager.go
@@ -91,8 +91,68 @@ func NewManager(config ManagerConfig, store *Store, starter ProcessStarter) *Man
 	}
 	manager.pool.SetObserver(func(item Item) {
 		_ = manager.store.RecordPoolState(context.Background(), item)
+		// Cooldowns live in memory only, so every managed update (they run
+		// daily) used to wipe them and let a just-quarantined account walk
+		// straight back into rotation. Persist on every state change.
+		_ = manager.store.SaveCooldowns(context.Background(), item.ID, cooldownRows(item))
 	})
 	return manager
+}
+
+// cooldownRows flattens one pool item into persisted cooldown rows: the
+// account-wide cooldown plus any model-scoped ones.
+func cooldownRows(item Item) []CooldownRow {
+	rows := make([]CooldownRow, 0, 1+len(item.ModelDownUntil))
+	if !item.DownUntil.IsZero() {
+		rows = append(rows, CooldownRow{
+			AccountID: item.ID, DownUntil: item.DownUntil,
+			BackoffLevel: item.BackoffLevel, Kind: item.LastKind, Message: item.LastError,
+		})
+	}
+	for model, until := range item.ModelDownUntil {
+		if until.IsZero() {
+			continue
+		}
+		rows = append(rows, CooldownRow{
+			AccountID: item.ID, Model: model, DownUntil: until,
+			BackoffLevel: item.BackoffLevel, Kind: item.LastKind, Message: item.LastError,
+		})
+	}
+	return rows
+}
+
+// restoreCooldowns reloads persisted cooldowns into the pool after accounts
+// are registered. Managed updates recreate the container regularly, and
+// without this a rate-limited account would be retried immediately on boot.
+func (m *Manager) restoreCooldowns(ctx context.Context) {
+	rows, err := m.store.LoadCooldowns(ctx)
+	if err != nil {
+		log.Printf("restore cooldowns: %v", err)
+		return
+	}
+	restored := 0
+	for _, row := range rows {
+		item, ok := m.pool.ByID(row.AccountID)
+		if !ok {
+			continue
+		}
+		if row.BackoffLevel > item.BackoffLevel {
+			item.BackoffLevel = row.BackoffLevel
+		}
+		if row.Model == "" {
+			item.DownUntil = row.DownUntil
+		} else {
+			if item.ModelDownUntil == nil {
+				item.ModelDownUntil = map[string]time.Time{}
+			}
+			item.ModelDownUntil[row.Model] = row.DownUntil
+		}
+		m.pool.Upsert(item)
+		restored++
+	}
+	if restored > 0 {
+		log.Printf("restored %d cooldown(s) from SQLite", restored)
+	}
 }
 
 func (m *Manager) Start(ctx context.Context) error {
@@ -108,6 +168,8 @@ func (m *Manager) Start(ctx context.Context) error {
 			m.pool.MarkDown(account.ID, 0, err.Error())
 		}
 	}
+	// After registration so there is an item to restore into.
+	m.restoreCooldowns(ctx)
 	return nil
 }
 
@@ -188,6 +250,7 @@ func (m *Manager) startAccount(ctx context.Context, account Account) error {
 		m.pool.Upsert(Item{
 			ID: account.ID, Provider: descriptor.ID, Region: account.ProviderRegion,
 			Runtime: string(descriptor.Runtime), DropSystemPrompt: account.DropSystemPrompt,
+			Weight: NormalizeWeight(account.Priority), MaxInFlight: account.MaxInFlight,
 		})
 		return nil
 	}
@@ -217,6 +280,7 @@ func (m *Manager) startAccount(ctx context.Context, account Account) error {
 	m.pool.Upsert(Item{
 		ID: account.ID, URL: process.URL(), Provider: descriptor.ID,
 		Region: account.ProviderRegion, Runtime: string(descriptor.Runtime), Restarts: restarts,
+		Weight: NormalizeWeight(account.Priority), MaxInFlight: account.MaxInFlight,
 	})
 	go m.watchAccount(account.ID, process)
 	return nil

--- a/internal/accounts/migrations.go
+++ b/internal/accounts/migrations.go
@@ -158,6 +158,18 @@ ALTER TABLE provider_model_settings ADD COLUMN reasoning_effort TEXT NOT NULL DE
 ALTER TABLE accounts ADD COLUMN workbuddy_auto_checkin INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE accounts ADD COLUMN last_checkin_at TEXT NOT NULL DEFAULT '';
 ALTER TABLE accounts ADD COLUMN last_checkin_msg TEXT NOT NULL DEFAULT '';`},
+	{filename: "011_account_cooldowns.sql", sql: `
+CREATE TABLE IF NOT EXISTS account_cooldowns (
+  account_id TEXT NOT NULL,
+  model TEXT NOT NULL DEFAULT '',
+  down_until TEXT NOT NULL,
+  backoff_level INTEGER NOT NULL DEFAULT 0,
+  kind TEXT NOT NULL DEFAULT '',
+  message TEXT NOT NULL DEFAULT '',
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (account_id, model)
+);
+CREATE INDEX IF NOT EXISTS account_cooldowns_until ON account_cooldowns(down_until);`},
 }
 
 const schemaMigrationsDDL = `

--- a/internal/accounts/pool.go
+++ b/internal/accounts/pool.go
@@ -1,6 +1,7 @@
 package accounts
 
 import (
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -23,25 +24,39 @@ type QuotaSnapshot struct {
 }
 
 type Item struct {
-	ID        string
-	URL       string
-	Provider  string
-	Region    string
-	Runtime   string
+	ID       string
+	URL      string
+	Provider string
+	Region   string
+	Runtime  string
+	// Weight is the per-account scheduling weight (1..100). Accounts share
+	// the default, so the pool stays a plain round-robin until an operator
+	// differentiates them.
+	Weight    int
 	DownUntil time.Time
 	LastError string
 	LastKind  string
 	Ready     *bool
 	Hot       *bool
 	InFlight  int
-	Restarts  int
-	Quota     *QuotaSnapshot
+	// MaxInFlight caps concurrent requests routed to this account. Zero
+	// means unknown and does not block routing.
+	MaxInFlight int
+	Restarts    int
+	Quota       *QuotaSnapshot
 	// Models is the last successful per-account catalog snapshot. A nil
 	// slice means unknown (fail open); a non-nil slice, including empty,
 	// is used to filter PublicModel. Entries keep the provider-native
 	// spelling so Trae config_name case is preserved.
 	Models   []string
 	ModelsAt time.Time
+	// ModelDownUntil is per-model cooldown. One model hitting a limit must
+	// not take the whole account offline for other models.
+	ModelDownUntil map[string]time.Time
+	// BackoffLevel climbs on repeated failures of the same kind and resets
+	// on success, so a persistently failing account backs off instead of
+	// being retried at a fixed interval.
+	BackoffLevel int
 	// DropSystemPrompt mirrors the stored account flag so the executor can
 	// sanitize requests per account without a store lookup per chat.
 	DropSystemPrompt bool
@@ -128,6 +143,24 @@ func providerAllowed(provider string, allowed []string) bool {
 	return false
 }
 
+// NormalizeWeight maps a stored priority onto a scheduling weight. The
+// console exposes 1..100 with 50 as the default; anything outside the range
+// falls back to the default so a bad row cannot distort rotation.
+func NormalizeWeight(priority int) int {
+	if priority < 1 || priority > 100 {
+		return defaultWeight
+	}
+	return priority
+}
+
+const defaultWeight = 50
+
+// itemWeight is the effective scheduling weight. Every account at the default
+// keeps plain round-robin; differentiated accounts are picked proportionally.
+func itemWeight(item Item) int {
+	return NormalizeWeight(item.Weight)
+}
+
 func routeMatches(item Item, q RouteQuery) bool {
 	if _, skip := q.Excluded[item.ID]; skip {
 		return false
@@ -148,10 +181,44 @@ func routeMatches(item Item, q RouteQuery) bool {
 }
 
 type Pool struct {
-	mu       sync.Mutex
-	items    []Item
-	next     int
-	observer func(Item)
+	mu    sync.Mutex
+	items []Item
+	// lastPicked tracks the rotation cursor per route, keyed by
+	// provider|region|model, as the *ID* of the previous pick.
+	//
+	// A numeric index into a shrinking candidate set silently re-seats the
+	// rotation: candidates drop out whenever a retry excludes an account, an
+	// account enters cooldown, or a model becomes unavailable. Indexing a
+	// monotonic counter into that changing slice starves some accounts and
+	// hammers others. Keying on the previous pick's ID resumes rotation at
+	// the account that follows it, whatever happened in between.
+	lastPicked map[string]string
+	// lastRegion remembers the region a route was last served from. Request
+	// handlers pin the region from whichever account is picked first, so an
+	// unpinned pick decides the region for the whole request. Without this a
+	// mixed-region pool would flip between regions as rotation advances.
+	lastRegion map[string]string
+	// weightCounter holds smooth-WRR running counters per route, keyed like
+	// lastPicked and then by account ID. Only used when weights differ.
+	weightCounter map[string]map[string]int64
+	observer      func(Item)
+}
+
+// rotationLimit bounds the cursor map so long-tailed model IDs cannot grow it
+// without bound. Hitting the limit resets every route's cursor, which costs
+// one rotation reseed rather than unbounded memory.
+const rotationLimit = 4096
+
+func rotationKey(q RouteQuery) string {
+	model := routeModel(q.PublicModel)
+	return providerFilterKey(q) + "|" + itemRegion(Item{Region: q.RegionFilter}) + "|" + model
+}
+
+func providerFilterKey(q RouteQuery) string {
+	if q.ProviderFilter != "" {
+		return strings.ToLower(strings.TrimSpace(q.ProviderFilter))
+	}
+	return "*"
 }
 
 func NewPool(urls []string, ids []string) *Pool {
@@ -258,26 +325,206 @@ func (p *Pool) PickRoute(q RouteQuery) (Item, bool) {
 		// to normal scheduling like the pre-provider pool did. A cooling pin
 		// sticky-escapes among eligible accounts that still serve the model.
 	}
-	n := len(p.items)
-	for i := 0; i < n; i++ {
-		idx := (p.next + i) % n
-		item := p.items[idx]
-		if !routeMatches(item, q) || itemDown(item, now) {
-			continue
-		}
-		p.next = (idx + 1) % n
-		return item, true
-	}
-	var best Item
-	found := false
+	// Candidates that are ready right now. Sorted by ID so the rotation
+	// cursor can resume from the previous pick even as the set changes.
+	available := make([]Item, 0, len(eligible))
 	for _, i := range eligible {
 		item := p.items[i]
-		if !found || item.DownUntil.Before(best.DownUntil) {
-			best = item
-			found = true
+		if !itemDown(item, now) && !itemModelDown(item, q, now) && !itemSaturated(item) {
+			available = append(available, item)
 		}
 	}
-	return best, found
+	if len(available) == 0 {
+		// Everything is cooling or saturated. Surface the item that frees up
+		// soonest so the caller can report a classified error with a retry
+		// hint, rather than silently picking an arbitrary account.
+		var best Item
+		found := false
+		for _, i := range eligible {
+			item := p.items[i]
+			if !found || resumeAt(item, q).Before(resumeAt(best, q)) {
+				best = item
+				found = true
+			}
+		}
+		return best, found
+	}
+	sort.Slice(available, func(i, j int) bool { return available[i].ID < available[j].ID })
+	key := rotationKey(q)
+	p.ensureRotationKey(key)
+	// When the caller has not pinned a region, keep serving the region this
+	// route used last (if it still has a candidate). Request handlers pin the
+	// region from the first account picked, so an unpinned pick decides the
+	// region for the whole request; letting rotation decide it would flip
+	// regions as rotation advances. On a cold route there is no history, so
+	// pick the region with the most candidates and remember it — starting at
+	// the alphabetically first account would otherwise let one small region
+	// capture the route.
+	if q.RegionFilter == "" {
+		if previous, ok := p.lastRegion[key]; ok {
+			if subset := inRegion(available, previous); len(subset) > 0 {
+				available = subset
+			}
+		}
+		if _, ok := p.lastRegion[key]; !ok {
+			if preferred := largestRegion(available); preferred != "" {
+				p.lastRegion[key] = preferred
+				if subset := inRegion(available, preferred); len(subset) > 0 {
+					available = subset
+				}
+			}
+		}
+	} else {
+		p.lastRegion[key] = itemRegion(available[0])
+	}
+	if weighted, ok := p.pickWeighted(available, key); ok {
+		// Differentiated weights: smooth weighted round-robin keeps the load
+		// proportional without bursting one high-weight account first.
+		p.lastPicked[key] = weighted.ID
+		p.lastRegion[key] = itemRegion(weighted)
+		return weighted, true
+	}
+	picked := available[successorIndex(available, p.lastPicked[key])]
+	p.lastPicked[key] = picked.ID
+	p.lastRegion[key] = itemRegion(picked)
+	return picked, true
+}
+
+// pickWeighted runs smooth weighted round-robin when candidates have differing
+// weights. It reports false when every candidate shares one weight, which
+// leaves plain round-robin in charge: with a uniform pool the two are
+// equivalent, and the ID cursor is what keeps rotation stable across a
+// changing candidate set.
+func (p *Pool) pickWeighted(available []Item, key string) (Item, bool) {
+	total := int64(0)
+	uniform := true
+	first := itemWeight(available[0])
+	for _, item := range available {
+		weight := int64(itemWeight(item))
+		total += weight
+		if weight != int64(first) {
+			uniform = false
+		}
+	}
+	if uniform || total <= 0 {
+		return Item{}, false
+	}
+	if p.weightCounter == nil {
+		p.weightCounter = map[string]map[string]int64{}
+	}
+	if p.weightCounter[key] == nil {
+		p.weightCounter[key] = map[string]int64{}
+	}
+	// Smooth WRR: add each candidate's weight to its running counter and take
+	// the largest, then subtract the total from the winner. This spreads picks
+	// evenly across a window instead of front-loading the heaviest candidate.
+	best := -1
+	var bestCurrent int64
+	for i := range available {
+		current := p.weightCounter[key][available[i].ID] + int64(itemWeight(available[i]))
+		p.weightCounter[key][available[i].ID] = current
+		if best < 0 || current > bestCurrent {
+			best = i
+			bestCurrent = current
+		}
+	}
+	if best < 0 {
+		return Item{}, false
+	}
+	p.weightCounter[key][available[best].ID] -= total
+	return available[best], true
+}
+
+// successorIndex returns the position of the first candidate ordered after
+// lastID, wrapping to the head. Candidates are sorted by ID, so this resumes
+// rotation at the account following the previous pick even when candidates
+// were filtered out in between. An empty lastID starts at the head.
+func successorIndex(available []Item, lastID string) int {
+	if lastID == "" {
+		return 0
+	}
+	index := sort.Search(len(available), func(i int) bool { return available[i].ID > lastID })
+	if index >= len(available) {
+		return 0
+	}
+	return index
+}
+
+// ensureRotationKey keeps the cursor map bounded. Must be called with p.mu held.
+func (p *Pool) ensureRotationKey(key string) {
+	if p.lastPicked == nil {
+		p.lastPicked = make(map[string]string)
+	}
+	if p.lastRegion == nil {
+		p.lastRegion = make(map[string]string)
+	}
+	if _, ok := p.lastPicked[key]; !ok && len(p.lastPicked) >= rotationLimit {
+		p.lastPicked = make(map[string]string)
+	}
+}
+
+// largestRegion returns the region with the most candidates, breaking ties by
+// name so the choice is stable across restarts rather than map-order random.
+func largestRegion(items []Item) string {
+	counts := map[string]int{}
+	for _, item := range items {
+		counts[itemRegion(item)]++
+	}
+	best := ""
+	bestCount := 0
+	for region, count := range counts {
+		if count > bestCount || (count == bestCount && (best == "" || region < best)) {
+			best = region
+			bestCount = count
+		}
+	}
+	return best
+}
+
+// inRegion narrows candidates to one region. An empty pool means that region
+// has nothing available right now and the caller should fall back to all.
+func inRegion(items []Item, region string) []Item {
+	out := make([]Item, 0, len(items))
+	for _, item := range items {
+		if itemRegion(item) == region {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+// itemSaturated reports whether the account already serves its configured
+// concurrency limit. max_inflight was stored but never enforced, so a single
+// account could absorb every concurrent request during a burst.
+func itemSaturated(item Item) bool {
+	if item.MaxInFlight <= 0 {
+		return false
+	}
+	return item.InFlight >= item.MaxInFlight
+}
+
+// itemModelDown applies the per-model cooldown: one model hitting a limit
+// must not take the whole account offline for other models.
+func itemModelDown(item Item, q RouteQuery, now time.Time) bool {
+	model := routeModel(q.PublicModel)
+	if model == "" {
+		return false
+	}
+	until, ok := item.ModelDownUntil[model]
+	return ok && now.Before(until)
+}
+
+// resumeAt is the moment an item becomes usable again for this route,
+// considering both account-level and model-level cooldowns.
+func resumeAt(item Item, q RouteQuery) time.Time {
+	next := item.DownUntil
+	model := routeModel(q.PublicModel)
+	if model != "" {
+		if until, ok := item.ModelDownUntil[model]; ok && (next.IsZero() || until.After(next)) {
+			next = until
+		}
+	}
+	return next
 }
 
 func (p *Pool) MarkDown(id string, d time.Duration, err string) {
@@ -295,9 +542,31 @@ func (p *Pool) MarkClassified(id string, c Classified) {
 			continue
 		}
 		p.items[i].LastError = c.Message
-		p.items[i].LastKind = c.Kind
+		if c.Kind != KindInvalidRequest {
+			p.items[i].LastKind = c.Kind
+		}
 		if c.Cooldown > 0 && (c.Failover || c.Kind != KindQuota) {
-			p.items[i].DownUntil = time.Now().Add(c.Cooldown)
+			// Repeated failures of the same kind back off exponentially so a
+			// persistently broken account stops consuming attempts at a fixed
+			// interval. A new failure kind starts the ladder over.
+			if p.items[i].LastKind == c.Kind && c.Kind != KindInvalidRequest {
+				p.items[i].BackoffLevel++
+			}
+			cooldown := c.Cooldown
+			if p.items[i].BackoffLevel > 1 {
+				cooldown, _ = nextBackoffCooldown(c.Cooldown, p.items[i].BackoffLevel-1)
+			}
+			until := time.Now().Add(cooldown)
+			if model := routeModel(c.Model); model != "" {
+				// Scope to one model: a rate limit on glm-5.3 must not take
+				// the account offline for deepseek-v4-flash.
+				if p.items[i].ModelDownUntil == nil {
+					p.items[i].ModelDownUntil = map[string]time.Time{}
+				}
+				p.items[i].ModelDownUntil[model] = until
+			} else {
+				p.items[i].DownUntil = until
+			}
 		}
 		copy := p.items[i]
 		changed = &copy
@@ -321,6 +590,10 @@ func (p *Pool) MarkOK(id string) {
 			p.items[i].DownUntil = time.Time{}
 			p.items[i].LastError = ""
 			p.items[i].LastKind = ""
+			// Success clears the backoff ladder and any model-scoped
+			// cooldowns: the account proved it can serve traffic again.
+			p.items[i].BackoffLevel = 0
+			p.items[i].ModelDownUntil = nil
 			copy := p.items[i]
 			changed = &copy
 			break
@@ -508,9 +781,31 @@ func (p *Pool) Upsert(item Item) {
 	defer p.mu.Unlock()
 	for i := range p.items {
 		if p.items[i].ID == item.ID {
-			item.DownUntil = p.items[i].DownUntil
-			item.LastError = p.items[i].LastError
-			item.LastKind = p.items[i].LastKind
+			// Carry runtime state forward, but only when the caller did not
+			// supply a value. Restoring persisted cooldowns needs to write
+			// these fields; the old unconditional copy silently discarded
+			// them.
+			if item.DownUntil.IsZero() {
+				item.DownUntil = p.items[i].DownUntil
+			}
+			if item.LastError == "" {
+				item.LastError = p.items[i].LastError
+			}
+			if item.LastKind == "" {
+				item.LastKind = p.items[i].LastKind
+			}
+			if item.BackoffLevel == 0 {
+				item.BackoffLevel = p.items[i].BackoffLevel
+			}
+			if item.ModelDownUntil == nil {
+				item.ModelDownUntil = p.items[i].ModelDownUntil
+			}
+			if item.Weight == 0 {
+				item.Weight = p.items[i].Weight
+			}
+			if item.MaxInFlight == 0 {
+				item.MaxInFlight = p.items[i].MaxInFlight
+			}
 			if item.Ready == nil {
 				item.Ready = p.items[i].Ready
 			}
@@ -541,13 +836,23 @@ func (p *Pool) Remove(id string) {
 		if p.items[i].ID != id {
 			continue
 		}
+		// The rotation cursor stores the previous pick's ID, so a removed
+		// account is skipped naturally; only a cursor pointing at it needs
+		// clearing.
 		p.items = append(p.items[:i], p.items[i+1:]...)
-		if len(p.items) == 0 {
-			p.next = 0
-		} else if p.next >= len(p.items) {
-			p.next %= len(p.items)
-		}
+		p.dropRotationCursor(id)
 		return
+	}
+}
+
+// dropRotationCursor clears any route whose cursor points at a removed
+// account, so rotation restarts at the head instead of resuming from an ID
+// that no longer exists. Must be called with p.mu held.
+func (p *Pool) dropRotationCursor(id string) {
+	for key, picked := range p.lastPicked {
+		if picked == id {
+			delete(p.lastPicked, key)
+		}
 	}
 }
 

--- a/internal/accounts/pool_test.go
+++ b/internal/accounts/pool_test.go
@@ -70,3 +70,168 @@ func TestPickSkipsQuotaCooldownOnlyWhenMarkedDown(t *testing.T) {
 		t.Fatalf("rate-limited a should be skipped, got %+v", next)
 	}
 }
+
+// A numeric rotation cursor silently re-seats rotation when the candidate set
+// shrinks (a retry excludes an account, or one enters cooldown), starving some
+// accounts and hammering others. The cursor must resume from the previous
+// pick's identity instead.
+func TestRotationSurvivesShrinkingCandidateSet(t *testing.T) {
+	p := NewPool([]string{"http://a:3020", "http://b:3020", "http://c:3020", "http://d:3020"},
+		[]string{"a", "b", "c", "d"})
+	picks := map[string]int{}
+	for i := 0; i < 8; i++ {
+		item, ok := p.Pick("", nil)
+		if !ok {
+			t.Fatalf("pick %d failed", i)
+		}
+		picks[item.ID]++
+	}
+	for _, id := range []string{"a", "b", "c", "d"} {
+		if picks[id] != 2 {
+			t.Fatalf("even rotation expected 2 picks each, got %v", picks)
+		}
+	}
+
+	// Take b out the way a retry exclusion or cooldown would. Rotation must
+	// continue from c, not restart at a.
+	excluded := map[string]struct{}{"b": {}}
+	got := map[string]int{}
+	for i := 0; i < 6; i++ {
+		item, _ := p.Pick("", excluded)
+		got[item.ID]++
+	}
+	for _, id := range []string{"a", "c", "d"} {
+		if got[id] != 2 {
+			t.Fatalf("b excluded: expected 2 picks each, got %v", got)
+		}
+	}
+	if got["b"] != 0 {
+		t.Fatalf("excluded b was picked: %v", got)
+	}
+}
+
+func TestMaxInFlightCapsConcurrency(t *testing.T) {
+	p := NewPool([]string{"http://a:3020", "http://b:3020"}, []string{"a", "b"})
+	p.Upsert(Item{ID: "a", MaxInFlight: 1})
+	p.Upsert(Item{ID: "b", MaxInFlight: 1})
+	p.MergeHealth("a", true, false, 1, 0, "")
+	p.MergeHealth("b", true, false, 0, 0, "")
+
+	// a is saturated at its limit, so traffic must move to b.
+	item, ok := p.Pick("", nil)
+	if !ok || item.ID != "b" {
+		t.Fatalf("saturated account must be skipped, got %+v", item)
+	}
+	// Both saturated: fall back to reporting the least-bad candidate.
+	p.MergeHealth("b", true, false, 1, 0, "")
+	if _, ok := p.Pick("", nil); !ok {
+		t.Fatal("fully saturated pool must still surface a candidate")
+	}
+}
+
+func TestMaxInFlightUnsetDoesNotBlock(t *testing.T) {
+	p := NewPool([]string{"http://a:3020"}, []string{"a"})
+	p.MergeHealth("a", true, false, 999, 0, "")
+	if _, ok := p.Pick("", nil); !ok {
+		t.Fatal("an unset limit must not block routing")
+	}
+}
+
+func TestWeightedRotationIsProportional(t *testing.T) {
+	p := NewPool([]string{"http://a:3020", "http://b:3020"}, []string{"a", "b"})
+	p.Upsert(Item{ID: "a", Weight: 90})
+	p.Upsert(Item{ID: "b", Weight: 10})
+	counts := map[string]int{}
+	for i := 0; i < 20; i++ {
+		item, _ := p.Pick("", nil)
+		counts[item.ID]++
+	}
+	if counts["a"] != 18 || counts["b"] != 2 {
+		t.Fatalf("weight 90:10 over 20 picks = %v", counts)
+	}
+}
+
+func TestUniformWeightsUsePlainRoundRobin(t *testing.T) {
+	p := NewPool([]string{"http://a:3020", "http://b:3020"}, []string{"a", "b"})
+	p.Upsert(Item{ID: "a", Weight: 50})
+	p.Upsert(Item{ID: "b", Weight: 50})
+	counts := map[string]int{}
+	for i := 0; i < 8; i++ {
+		item, _ := p.Pick("", nil)
+		counts[item.ID]++
+	}
+	if counts["a"] != 4 || counts["b"] != 4 {
+		t.Fatalf("uniform weights must stay even, got %v", counts)
+	}
+}
+
+func TestModelCooldownLeavesOtherModelsAvailable(t *testing.T) {
+	p := NewPool([]string{"http://a:3020"}, []string{"a"})
+	p.MarkClassified("a", Classified{Kind: KindRateLimit, Cooldown: time.Hour, Failover: true, Model: "glm-5.3"})
+
+	item, _ := p.PickRoute(RouteQuery{PublicModel: "glm-5.3"})
+	if item.ID != "a" {
+		t.Fatalf("all cooling: must still surface the account, got %+v", item)
+	}
+	// No candidate is down for a different model, so the account serves it.
+	if item, ok := p.PickRoute(RouteQuery{PublicModel: "deepseek-v4-flash"}); !ok || item.ID != "a" {
+		t.Fatalf("model-scoped cooldown must not block other models, got %+v ok=%v", item, ok)
+	}
+}
+
+func TestAccountCooldownBlocksEveryModel(t *testing.T) {
+	p := NewPool([]string{"http://a:3020", "http://b:3020"}, []string{"a", "b"})
+	p.MarkClassified("a", Classified{Kind: KindUnavailable, Cooldown: time.Hour, Failover: true})
+	counts := map[string]int{}
+	for i := 0; i < 4; i++ {
+		item, _ := p.PickRoute(RouteQuery{PublicModel: "glm-5.3"})
+		counts[item.ID]++
+	}
+	if counts["a"] != 0 || counts["b"] != 4 {
+		t.Fatalf("account-wide cooldown must block all models, got %v", counts)
+	}
+}
+
+func TestRepeatedFailuresBackOff(t *testing.T) {
+	p := NewPool([]string{"http://a:3020"}, []string{"a"})
+	base := 30 * time.Second
+	p.MarkClassified("a", Classified{Kind: KindRateLimit, Cooldown: base, Failover: true})
+	first, _ := p.ByID("a")
+
+	p.MarkClassified("a", Classified{Kind: KindRateLimit, Cooldown: base, Failover: true})
+	second, _ := p.ByID("a")
+	if !second.DownUntil.After(first.DownUntil) {
+		t.Fatalf("repeat failure must extend the cooldown: %v then %v", first.DownUntil, second.DownUntil)
+	}
+	if second.BackoffLevel < first.BackoffLevel {
+		t.Fatalf("backoff level must climb: %d then %d", first.BackoffLevel, second.BackoffLevel)
+	}
+
+	// Success clears the ladder.
+	p.MarkOK("a")
+	reset, _ := p.ByID("a")
+	if reset.BackoffLevel != 0 || !reset.DownUntil.IsZero() {
+		t.Fatalf("MarkOK must reset backoff: %+v", reset)
+	}
+}
+
+func TestBackoffIsCapped(t *testing.T) {
+	for level := 0; level < 40; level++ {
+		d, next := nextBackoffCooldown(time.Minute, level)
+		if d > backoffCeiling {
+			t.Fatalf("level %d cooldown %v exceeds ceiling %v", level, d, backoffCeiling)
+		}
+		if next > backoffMaxLevel && next != level {
+			t.Fatalf("level %d returned next %d past the cap", level, next)
+		}
+	}
+}
+
+func TestNormalizeWeight(t *testing.T) {
+	cases := map[int]int{0: 50, 1: 1, 50: 50, 100: 100, 101: 50, -5: 50}
+	for input, want := range cases {
+		if got := NormalizeWeight(input); got != want {
+			t.Fatalf("NormalizeWeight(%d)=%d want %d", input, got, want)
+		}
+	}
+}

--- a/internal/accounts/store.go
+++ b/internal/accounts/store.go
@@ -599,6 +599,98 @@ WHERE id = ?`, formatTime(at), strings.TrimSpace(msg), formatTime(time.Now().UTC
 	return nil
 }
 
+// canonicalCooldownModel normalizes a model key for storage. Unlike
+// CanonicalModelID it leaves the empty key alone: "" is a real primary-key
+// value meaning "account-wide", and CanonicalModelID would rewrite it to
+// "auto", collapsing the account row into the model namespace.
+func canonicalCooldownModel(model string) string {
+	if strings.TrimSpace(model) == "" {
+		return ""
+	}
+	return CanonicalModelID(model)
+}
+
+// CooldownRow is one persisted cooldown: account-wide when Model is empty,
+// scoped to a single canonical model otherwise.
+type CooldownRow struct {
+	AccountID    string
+	Model        string
+	DownUntil    time.Time
+	BackoffLevel int
+	Kind         string
+	Message      string
+}
+
+// SaveCooldowns replaces the persisted cooldown set for one account. Rows
+// whose deadline already passed are dropped instead of being written, so a
+// long-lived process cannot accumulate expired entries.
+func (s *Store) SaveCooldowns(ctx context.Context, accountID string, rows []CooldownRow) error {
+	if accountID == "" {
+		return nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin cooldown save: %w", err)
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx, `DELETE FROM account_cooldowns WHERE account_id = ?`, accountID); err != nil {
+		return fmt.Errorf("clear cooldowns: %w", err)
+	}
+	now := time.Now().UTC()
+	for _, row := range rows {
+		if row.DownUntil.IsZero() || !now.Before(row.DownUntil) {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO account_cooldowns (account_id, model, down_until, backoff_level, kind, message, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(account_id, model) DO UPDATE SET
+  down_until = excluded.down_until,
+  backoff_level = excluded.backoff_level,
+  kind = excluded.kind,
+  message = excluded.message,
+  updated_at = excluded.updated_at`,
+			accountID, canonicalCooldownModel(row.Model), formatTime(row.DownUntil), row.BackoffLevel,
+			row.Kind, row.Message, formatTime(now)); err != nil {
+			return fmt.Errorf("save cooldown: %w", err)
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM account_cooldowns WHERE account_id = ? AND down_until <= ?`,
+		accountID, formatTime(now)); err != nil {
+		return fmt.Errorf("prune cooldowns: %w", err)
+	}
+	return tx.Commit()
+}
+
+// LoadCooldowns returns every cooldown whose deadline is still in the future.
+// Expired rows are pruned in the same statement so repeated restarts do not
+// re-read stale entries.
+func (s *Store) LoadCooldowns(ctx context.Context) ([]CooldownRow, error) {
+	now := formatTime(time.Now().UTC())
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM account_cooldowns WHERE down_until <= ?`, now); err != nil {
+		return nil, fmt.Errorf("prune expired cooldowns: %w", err)
+	}
+	rows, err := s.db.QueryContext(ctx, `
+SELECT account_id, model, down_until, backoff_level, kind, message
+FROM account_cooldowns WHERE down_until > ? ORDER BY account_id, model`, now)
+	if err != nil {
+		return nil, fmt.Errorf("load cooldowns: %w", err)
+	}
+	defer rows.Close()
+	var out []CooldownRow
+	for rows.Next() {
+		var row CooldownRow
+		var until, model string
+		if err := rows.Scan(&row.AccountID, &model, &until, &row.BackoffLevel, &row.Kind, &row.Message); err != nil {
+			return nil, fmt.Errorf("scan cooldown: %w", err)
+		}
+		row.DownUntil = parseTime(until)
+		row.Model = canonicalCooldownModel(model)
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
 func (s *Store) RecordPoolState(ctx context.Context, item Item) error {
 	var cooldown any
 	status := "ready"

--- a/internal/accounts/store_test.go
+++ b/internal/accounts/store_test.go
@@ -426,3 +426,115 @@ func TestNextWorkBuddyFireKinds(t *testing.T) {
 
 func boolPtr(value bool) *bool { return &value }
 func intPtr(value int) *int    { return &value }
+
+// Managed updates recreate the container regularly, and cooldowns used to live
+// only in memory: a just-quarantined account walked straight back into
+// rotation after every restart.
+func TestCooldownsSurviveReopen(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "qoder.db")
+
+	store, err := OpenStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	account, err := store.Create(ctx, CreateAccount{Name: "Work", Enabled: true, MaxInFlight: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	future := time.Now().UTC().Add(2 * time.Hour).Truncate(time.Second)
+	past := time.Now().UTC().Add(-time.Hour)
+	rows := []CooldownRow{
+		{AccountID: account.ID, DownUntil: future, BackoffLevel: 3, Kind: KindRateLimit, Message: "slow down"},
+		{AccountID: account.ID, Model: "glm-5.3", DownUntil: future, BackoffLevel: 2, Kind: KindQuota, Message: "out of quota"},
+		{AccountID: account.ID, Model: "expired-model", DownUntil: past, Kind: KindRateLimit},
+	}
+	if err := store.SaveCooldowns(ctx, account.ID, rows); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := OpenStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := reopened.LoadCooldowns(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded) != 2 {
+		t.Fatalf("expired rows must be pruned, got %d: %+v", len(loaded), loaded)
+	}
+	byModel := map[string]CooldownRow{}
+	for _, row := range loaded {
+		key := row.Model
+		if key == "" {
+			key = "<account>"
+		}
+		byModel[key] = row
+	}
+	accountWide, ok := byModel["<account>"]
+	if !ok || accountWide.BackoffLevel != 3 || !accountWide.DownUntil.Equal(future) {
+		t.Fatalf("account cooldown lost: %+v", accountWide)
+	}
+	scoped, ok := byModel["glm-5.3"]
+	if !ok || scoped.BackoffLevel != 2 || scoped.Kind != KindQuota {
+		t.Fatalf("model cooldown lost: %+v", scoped)
+	}
+}
+
+func TestSaveCooldownsReplacesStaleRows(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "qoder.db")
+	store, err := OpenStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	account, err := store.Create(ctx, CreateAccount{Name: "Work", Enabled: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	future := time.Now().UTC().Add(time.Hour)
+	if err := store.SaveCooldowns(ctx, account.ID, []CooldownRow{
+		{AccountID: account.ID, Model: "old-model", DownUntil: future, Kind: KindRateLimit},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveCooldowns(ctx, account.ID, []CooldownRow{
+		{AccountID: account.ID, Model: "new-model", DownUntil: future, Kind: KindRateLimit},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := store.LoadCooldowns(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded) != 1 || loaded[0].Model != "new-model" {
+		t.Fatalf("save must replace the account's rows, got %+v", loaded)
+	}
+}
+
+func TestLoadCooldownsPrunesExpired(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "qoder.db")
+	store, err := OpenStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	account, err := store.Create(ctx, CreateAccount{Name: "Work", Enabled: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale := time.Now().UTC().Add(-time.Minute)
+	if err := store.SaveCooldowns(ctx, account.ID, []CooldownRow{
+		{AccountID: account.ID, DownUntil: stale, Kind: KindRateLimit},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := store.LoadCooldowns(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded) != 0 {
+		t.Fatalf("expired cooldown must not be written or returned, got %+v", loaded)
+	}
+}

--- a/internal/api/chat.go
+++ b/internal/api/chat.go
@@ -353,7 +353,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			// executor's attempt loop never saw it. Feed the classified state
 			// back into the pool so the next request can route around a
 			// quota-exhausted account.
-			s.executor.ObserveStreamFailure(upstream.AccountID, relayErr)
+			s.executor.ObserveStreamFailure(upstream.AccountID, relayErr, publicModel)
 			panic(http.ErrAbortHandler)
 		}
 		return

--- a/internal/executor/chat.go
+++ b/internal/executor/chat.go
@@ -228,7 +228,7 @@ func isInProcessItem(item accounts.Item) bool {
 // error is the first place the failure is observable. Same-account retry is
 // impossible at that point (bytes are on the wire), so this only records the
 // classified state for the next request's scheduling.
-func (e ChatExecutor) ObserveStreamFailure(accountID string, err error) {
+func (e ChatExecutor) ObserveStreamFailure(accountID string, err error, model string) {
 	if e.Pool == nil || accountID == "" || err == nil {
 		return
 	}
@@ -251,12 +251,18 @@ func (e ChatExecutor) ObserveStreamFailure(accountID string, err error) {
 			classified.Cooldown = time.Hour
 		}
 	}
-	e.markClassified(accountID, classified)
+	e.markClassified(accountID, classified, model)
 }
 
-func (e ChatExecutor) markClassified(id string, c accounts.Classified) {
+// markClassified records a classified failure. model scopes the cooldown to
+// the requested public model so one rate-limited model does not take the
+// whole account offline; pass "" for an account-wide cooldown.
+func (e ChatExecutor) markClassified(id string, c accounts.Classified, model string) {
 	if e.Pool == nil || id == "" {
 		return
+	}
+	if c.Model == "" {
+		c.Model = model
 	}
 	e.Pool.MarkClassified(id, c)
 }
@@ -375,7 +381,7 @@ func (e ChatExecutor) ChatNonStream(ctx context.Context, req translate.ChatReque
 		if err != nil {
 			classified := accounts.Classify(0, err.Error(), "", accounts.KindUnavailable, "")
 			lastErr = fmt.Errorf("worker %s request failed: %w", item.ID, err)
-			e.markClassified(item.ID, classified)
+			e.markClassified(item.ID, classified, req.Model)
 			latency := int(time.Since(started).Milliseconds())
 			e.recordAttempt(ctx, accounts.RequestAttempt{
 				AttemptIndex: i, AccountID: item.ID, StartedAt: started, FinishedAt: ptrTime(time.Now().UTC()),
@@ -398,7 +404,7 @@ func (e ChatExecutor) ChatNonStream(ctx context.Context, req translate.ChatReque
 			if classified.Kind == accounts.KindModelNotAvailable {
 				e.Pool.RemoveModel(item.ID, req.Model)
 			}
-			e.markClassified(item.ID, classified)
+			e.markClassified(item.ID, classified, req.Model)
 			status := accounts.AttemptStatusError
 			if classified.Failover && i+1 < attempts {
 				status = accounts.AttemptStatusFailover
@@ -473,7 +479,7 @@ func (e ChatExecutor) chatInProcessNonStreamAttempt(ctx context.Context, item ac
 		if classified.Kind == accounts.KindModelNotAvailable {
 			e.Pool.RemoveModel(item.ID, req.Model)
 		}
-		e.markClassified(item.ID, classified)
+		e.markClassified(item.ID, classified, req.Model)
 		status := accounts.AttemptStatusError
 		if classified.Failover {
 			status = accounts.AttemptStatusFailover
@@ -519,7 +525,7 @@ func (e ChatExecutor) chatInProcessStreamAttempt(ctx context.Context, item accou
 		if classified.Kind == accounts.KindModelNotAvailable {
 			e.Pool.RemoveModel(item.ID, req.Model)
 		}
-		e.markClassified(item.ID, classified)
+		e.markClassified(item.ID, classified, req.Model)
 		status := accounts.AttemptStatusError
 		if classified.Failover {
 			status = accounts.AttemptStatusFailover
@@ -724,7 +730,7 @@ func (e ChatExecutor) ChatStreamProxy(ctx context.Context, req translate.ChatReq
 		if err != nil {
 			classified := accounts.Classify(0, err.Error(), "", accounts.KindUnavailable, "")
 			lastErr = fmt.Errorf("worker %s stream request failed: %w", item.ID, err)
-			e.markClassified(item.ID, classified)
+			e.markClassified(item.ID, classified, req.Model)
 			latency := int(time.Since(started).Milliseconds())
 			e.recordAttempt(ctx, accounts.RequestAttempt{
 				AttemptIndex: i, AccountID: item.ID, StartedAt: started, FinishedAt: ptrTime(time.Now().UTC()),
@@ -745,7 +751,7 @@ func (e ChatExecutor) ChatStreamProxy(ctx context.Context, req translate.ChatReq
 			if classified.Kind == accounts.KindModelNotAvailable {
 				e.Pool.RemoveModel(item.ID, req.Model)
 			}
-			e.markClassified(item.ID, classified)
+			e.markClassified(item.ID, classified, req.Model)
 			finished := time.Now().UTC()
 			latency := int(finished.Sub(started).Milliseconds())
 			status := accounts.AttemptStatusError

--- a/internal/executor/chat_test.go
+++ b/internal/executor/chat_test.go
@@ -343,7 +343,7 @@ func TestObserveStreamFailureCoolsDownQuotaAccount(t *testing.T) {
 		Kind:    accounts.KindQuota,
 		Status:  429,
 		Message: "Your requests have exceeded the quota.",
-	})
+	}, "deepseek-v4-flash")
 
 	item, ok := pool.ByID("acc-quota")
 	if !ok {
@@ -352,8 +352,31 @@ func TestObserveStreamFailureCoolsDownQuotaAccount(t *testing.T) {
 	if item.LastKind != accounts.KindQuota {
 		t.Fatalf("last kind=%q want %q", item.LastKind, accounts.KindQuota)
 	}
+	// The failure carries a model, so the cooldown is scoped to that model
+	// and the account stays available for every other model.
+	until, scoped := item.ModelDownUntil["deepseek-v4-flash"]
+	if !scoped || until.IsZero() {
+		t.Fatalf("quota failure must cool the model, got %v", item.ModelDownUntil)
+	}
+	if !item.DownUntil.IsZero() {
+		t.Fatalf("model-scoped failure must not take the whole account down: %v", item.DownUntil)
+	}
+}
+
+func TestObserveStreamFailureWithoutModelTakesAccountDown(t *testing.T) {
+	pool := accounts.NewPool([]string{"http://127.0.0.1:1"}, []string{"acc-quota"})
+	pool.Upsert(accounts.Item{ID: "acc-quota"})
+	ex := NewChatExecutor(pool, "")
+
+	ex.ObserveStreamFailure("acc-quota", &providers.Error{
+		Kind:    accounts.KindQuota,
+		Status:  429,
+		Message: "Your requests have exceeded the quota.",
+	}, "")
+
+	item, _ := pool.ByID("acc-quota")
 	if item.DownUntil.IsZero() {
-		t.Fatal("quota failure must schedule a cooldown")
+		t.Fatal("a failure with no model must cool the whole account")
 	}
 }
 
@@ -368,10 +391,10 @@ func TestObserveStreamFailureLeavesHealthyAccountAlone(t *testing.T) {
 		Kind:    accounts.KindInvalidRequest,
 		Status:  400,
 		Message: "a message has empty content",
-	})
+	}, "glm-5.3")
 	// No error at all also means no state change.
-	ex.ObserveStreamFailure("acc-ok", nil)
-	ex.ObserveStreamFailure("", &providers.Error{Kind: accounts.KindQuota})
+	ex.ObserveStreamFailure("acc-ok", nil, "glm-5.3")
+	ex.ObserveStreamFailure("", &providers.Error{Kind: accounts.KindQuota}, "glm-5.3")
 
 	item, _ := pool.ByID("acc-ok")
 	if item.LastKind != "" || !item.DownUntil.IsZero() {


### PR DESCRIPTION
Follows the comparison against `router-for-me/CLIProxyAPI`: six scheduling gaps, ordered by value. Full write-up is in `docs/capture-notes.md`.

## Changes

**Rotation stability (`internal/accounts/pool.go`)** — the cursor now resumes from the previously picked account's ID. CLIProxyAPI's comment describes exactly what we had:

> Candidate slices shrink whenever a retry excludes already tried credentials or a credential enters cooldown, and indexing a monotonic counter into a shrinking slice silently re-seats the rotation, which starves some credentials and hammers others.

This was visible in production — five accounts carried most traffic while ten sat near-idle.

**Concurrency limit** — `max_inflight` was stored and shown in the console but never read. It now gates selection.

**Cooldown persistence (migration `011_account_cooldowns.sql`)** — cooldowns were memory-only, so each managed update (daily) cleared them. Now saved on every state change and restored on start.

**Weight** — `priority` was settable through the API and console but unused by the scheduler: operators could set it with no effect and no warning. It now drives smooth weighted round-robin. Default 50 keeps plain round-robin, so existing pools are unaffected.

**Model-scoped cooldown** — one rate-limited model no longer takes the whole account offline.

**Exponential backoff** — repeated failures of the same kind cool progressively longer (cap 6h), reset on success.

**Region stickiness** — an unpinned route reuses its last region instead of letting rotation decide.

## Notes

Adding the ID cursor changed which account is picked first, which surfaced a latent issue: handlers pin the region from that first pick, so region selection was effectively arbitrary. It is now explicit — reuse the last region, or take the majority region when there is no history. Two tests caught this.

`Upsert` previously copied old values over incoming ones unconditionally, which would have discarded restored cooldowns; it now only inherits when the caller supplies nothing.

## Verification

- `go build`, `go vet`, `gofmt` clean; `go test ./...` passes, `-race` clean on accounts/executor/api
- 12 new tests: rotation continuity under a shrinking candidate set, concurrency caps, weight proportionality, uniform-weight equivalence, model vs account cooldown scope, backoff growth and cap, cooldown round-trip through SQLite, expired-row pruning
- Cooldown storage normalizes the empty model key separately: `CanonicalModelID("")` returns `"auto"`, which would have collapsed the account-wide row into the model namespace