### PR TITLE
docs: freeze changelog for v0.2.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### English
 
+### 中文
+
+## 0.2.30 - 2026-08-31
+
+### English
+
 - Clarify account quota usage on the Accounts page by showing used and remaining credits together
 
 ### 中文


### PR DESCRIPTION
## Summary
- move the published v0.2.30 notes out of Unreleased

## Validation
- `python3 scripts/release-notes.py freeze 0.2.30 --date 2026-08-31`
- `python3 scripts/release-notes.py validate`
- `git diff --check`