### PR TITLE
docs: freeze changelog for v0.2.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### English
 
+### 中文
+
+## 0.2.31 - 2026-09-01
+
+### English
+
 - Paginate the Accounts page so large pools render one page of cards at a time, with the same per-page control used on Logs and Models
 
 ### 中文


### PR DESCRIPTION
## Summary

- Move the published v0.2.31 notes out of Unreleased. The release workflow's `changelog` job cannot push this itself because `main` requires a pull request and status checks.

## Validation

- `python3 scripts/release-notes.py freeze 0.2.31 --date 2026-09-01`
- `python3 scripts/release-notes.py validate`
- `git diff --check`