### PR TITLE
docs: freeze changelog for v0.2.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### English
 
+### 中文
+
+## 0.2.34 - 2026-09-02
+
+### English
+
 - Make account failure handling scope-aware: quota, authentication, readiness, and upstream failures cool the whole account, while rate limits remain isolated to the affected model; cooling accounts no longer receive requests
 - Recognize nested CodeBuddy quota errors such as code `14018`, apply an account cooldown, and expose model-level cooldowns with precise `Retry-After` messages
 - Improve the Accounts console with compact cards, a single primary refresh action, matching skeleton dimensions, and live per-model cooldown indicators


### PR DESCRIPTION
## Summary
- 将已发布的 `v0.2.34` 双语 Unreleased 条目冻结到版本标题下
- 保留空的 `Unreleased` 区域，避免下一版本混入已发布内容

## Test plan
- `python3 scripts/release-notes.py self-test`
- `python3 scripts/release-notes.py validate`
- `git diff --check`