### PR TITLE
fix: skip unhealthy accounts during routing

### DIFF
--- a/internal/accounts/pool.go
+++ b/internal/accounts/pool.go
@@ -181,7 +181,14 @@ func itemWeight(item Item) int {
 	return NormalizeWeight(item.Weight)
 }
 
+func itemReady(item Item) bool {
+	return item.Ready == nil || *item.Ready
+}
+
 func routeMatches(item Item, q RouteQuery) bool {
+	if !itemReady(item) {
+		return false
+	}
 	if _, skip := q.Excluded[item.ID]; skip {
 		return false
 	}

--- a/internal/accounts/pool_test.go
+++ b/internal/accounts/pool_test.go
@@ -31,6 +31,28 @@ func TestRoundRobinSkipsDownAccounts(t *testing.T) {
 	}
 }
 
+func TestRoundRobinSkipsNotReadyAccounts(t *testing.T) {
+	p := NewPool([]string{"http://a:3020", "http://b:3020", "http://c:3020"}, []string{"a", "b", "c"})
+	p.MergeHealth("a", false, false, 0, 0, "account not found")
+
+	first, ok := p.Pick("", nil)
+	if !ok || first.ID != "b" {
+		t.Fatalf("not-ready a should be skipped, got %+v ok=%v", first, ok)
+	}
+
+	p.MergeHealth("b", false, false, 0, 0, "worker unavailable")
+	second, ok := p.Pick("", nil)
+	if !ok || second.ID != "c" {
+		t.Fatalf("not-ready b should be skipped, got %+v ok=%v", second, ok)
+	}
+
+	p.MergeHealth("a", true, true, 0, 0, "")
+	third, ok := p.Pick("", nil)
+	if !ok || third.ID != "a" {
+		t.Fatalf("ready a should rejoin rotation, got %+v ok=%v", third, ok)
+	}
+}
+
 func TestUpsertKeepsExistingQuota(t *testing.T) {
 	p := NewPool([]string{"http://a:3020"}, []string{"a"})
 	p.MergeQuota("a", &QuotaSnapshot{Remaining: 900, Total: 1000, Unit: "credits"})


### PR DESCRIPTION
## Summary
- skip accounts marked `Ready=false` during route matching
- preserve fail-open behavior for accounts with unknown readiness
- add round-robin regression coverage for unhealthy account exclusion and recovery

## Validation
- `go test ./...`
- `git diff --check`

This prevents known-unhealthy accounts such as stale `account not found` workers from consuming routing attempts before failover.