### PR TITLE
docs: freeze changelog for v0.2.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### English
 
+### 中文
+
+## 0.2.35 - 2026-09-03
+
+### English
+
 - Exclude accounts marked not ready from routing so stale workers do not consume failover attempts
 
 ### 中文


### PR DESCRIPTION
## Summary
- move the published v0.2.35 notes out of `Unreleased`
- preserve matching English and Chinese release bullets

## Validation
- `python3 scripts/release-notes.py validate`
- `git diff --check`

Per `docs/DEVELOPMENT.md`, this is a post-publication changelog freeze and does not rerun the release workflow.