### PR TITLE
docs: freeze changelog for v0.2.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### English
 
+### 中文
+
+## 0.2.38 - 2026-09-03
+
+### English
+
 - Keep cached account cards visible while health, quota, and model details refresh asynchronously, with inline skeletons and usable pagination
 
 ### 中文


### PR DESCRIPTION
## Summary
- freeze the already-published v0.2.38 bilingual changelog entry
- clear `Unreleased` so the next release starts cleanly

This is the protected-main follow-up for the release workflow changelog step.