### PR TITLE
fix: avoid expired account refresh contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### English
 
+- Prevent system updates and overview loading from reusing expired account-refresh contexts while checking account state
+
 ### 中文
+
+- 修复系统更新和 Overview 加载复用已过期账号刷新 context 的问题，避免账号列表查询超时
 
 ## 0.2.38 - 2026-09-03
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -285,8 +285,14 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleOverview(w http.ResponseWriter, r *http.Request) {
-	_ = s.manager.RefreshAll(r.Context(), r.URL.Query().Get("refresh") == "1")
-	accountViews, _ := s.manager.Accounts(r.Context())
+	refreshCtx, refreshCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	_ = s.manager.RefreshAll(refreshCtx, r.URL.Query().Get("refresh") == "1")
+	refreshCancel()
+	accountViews, err := s.manager.Accounts(r.Context())
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "account_list_failed", err.Error())
+		return
+	}
 	readyCount := 0
 	hotCount := 0
 	for _, account := range accountViews {

--- a/internal/api/update.go
+++ b/internal/api/update.go
@@ -248,14 +248,14 @@ func newSystemUpdateJobID() (string, error) {
 
 func (s *Server) waitForUpdateIdle(ctx context.Context) error {
 	for {
-		_ = s.manager.RefreshAll(ctx, false)
-		accounts, err := s.manager.Accounts(ctx)
-		if err != nil {
-			return err
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
 		}
 		inFlight := 0
-		for _, account := range accounts {
-			inFlight += account.InFlight
+		for _, item := range s.manager.Pool().Items() {
+			inFlight += item.InFlight
 		}
 		if inFlight == 0 {
 			return nil

--- a/internal/api/update_test.go
+++ b/internal/api/update_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/caigee-cmd/cli2api/internal/accounts"
 	"github.com/caigee-cmd/cli2api/internal/config"
 	control "github.com/caigee-cmd/cli2api/internal/update"
 )
@@ -141,6 +142,24 @@ func TestSystemUpdateDoesNotBackupWhenNoNextVersionExists(t *testing.T) {
 	entries, err := os.ReadDir(filepath.Join(dataDir, "backups"))
 	if err == nil && len(entries) != 0 {
 		t.Fatalf("unexpected backups: %v", entries)
+	}
+}
+
+func TestWaitForUpdateIdleReadsInFlightFromPool(t *testing.T) {
+	dataDir := t.TempDir()
+	srv := New(config.Config{
+		Host: "127.0.0.1", Port: 3010, ProxyAPIKey: "secret",
+		QoderHome: t.TempDir(), DataDir: dataDir,
+	})
+	defer srv.Close()
+
+	srv.manager.Pool().Upsert(accounts.Item{ID: "account-1", InFlight: 1})
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	err := srv.waitForUpdateIdle(ctx)
+	if err == nil || !strings.Contains(err.Error(), "1 request(s) are still in flight") || strings.Contains(err.Error(), "list accounts") {
+		t.Fatalf("expected in-flight timeout without account-list error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

-

## Test plan

- [ ] `go test ./...`
- [ ] `go vet ./...`
- [ ] `cd worker && npm test`
- [ ] `cd frontend && npm run build && npm run lint`
- [ ] No tokens, auth blobs, raw captures, or host details in the diff
