### PR TITLE
docs: freeze changelog for v0.2.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### English
 
+### 中文
+
+## 0.2.40 - 2026-09-03
+
+### English
+
 - Interrupt active connections instead of waiting for in-flight requests before managed updates; clients can retry interrupted requests
 - Load the Accounts page first, refresh account details in small batches, and default pagination to five accounts
 - Add compact WorkBuddy check-in status, check-in history, manual check-in, and scheduled daily check-ins around 09:00 and 21:00 local time


### PR DESCRIPTION
## Summary
- move the published v0.2.40 bilingual notes out of `Unreleased`
- complete the release workflow's changelog step through the protected-branch PR flow

## Validation
- `python3 scripts/release-notes.py validate`
- `git diff --check`
