### PR TITLE
docs: freeze changelog for v0.2.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### English
 
+### 中文
+
+## 0.2.41 - 2026-09-03
+
+### English
+
 - Make the account toolbar compact enough to keep common actions visible, with overflow reserved for secondary actions
 - Reduce account card density so account lists are easier to scan
 


### PR DESCRIPTION
## Summary
- move v0.2.41 release notes out of Unreleased
- keep the bilingual changelog structure valid after the release workflow

## Validation
- python3 scripts/release-notes.py validate