### PR TITLE
docs: freeze changelog for v0.2.43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### English
 
+### 中文
+
+## 0.2.43 - 2026-09-04
+
+### English
+
 - Polish the API access console with connection status, compact endpoint cards, and copy/open actions for supported routes
 - Expose the Anthropic Messages and OpenAI Responses routes in the console access catalog and overview metadata
 


### PR DESCRIPTION
## Summary
- move the published v0.2.43 notes out of Unreleased
- preserve the bilingual release notes in CHANGELOG.md

This is the protected-branch follow-up for the v0.2.43 release workflow.