### PR TITLE
docs: freeze changelog for v0.2.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### English
 
+### 中文
+
+## 0.2.44 - 2026-09-04
+
+### English
+
 - Document the staged update flow and its restart confirmation boundary for the next patch release
 
 ### 中文


### PR DESCRIPTION
归档 `v0.2.44` 的双语发布说明，并清空 `Unreleased`。

这是对 Release workflow 在受保护 `main` 上直接推送失败的补偿收尾。

验证：`make changelog`