### PR TITLE
docs: recommend Docker as the supported install and update path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### English
 
+- Recommend Docker Compose as the supported install and managed-update path in the README and deployment guide
+
 ### 中文
+
+- 在 README 与部署说明中明确推荐 Docker Compose 作为官方安装与托管更新路径
 
 ## 0.2.45 - 2026-09-05
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 支持 **Qoder 国际版**、**Qoder 国内版**、**WorkBuddy 国际版**、**WorkBuddy 国内版** 和 **Trae 国内版 Solo**。
 
-常驻运行时、多账号调度，Docker 一键启动。
+常驻运行时、多账号调度。请用 Docker 部署，这是官方支持的安装与更新路径。
 
 [![License](https://img.shields.io/github/license/caigee-cmd/cli2api)](LICENSE)
 [![LINUX DO](https://img.shields.io/badge/LINUX%20DO-community-ff6a00)](https://linux.do)
@@ -28,6 +28,8 @@
 - **跨平台**：`linux/amd64` / `linux/arm64` 镜像；macOS、Windows 通过 Docker Desktop 运行
 
 ## 快速开始
+
+**强烈建议用 Docker 部署。** 发布镜像、控制台托管更新（升级前快照、失败回滚、逐版本升级）都按单容器 Compose 安装来设计；从源码直接跑 Go / Node 不在这条更新路径上。
 
 依赖：Docker（macOS / Windows 用 Docker Desktop，Linux 用 Docker Engine + Compose），以及一个你自己控制的 Qoder、WorkBuddy 或 Trae 账号。Windows 的 Docker Desktop 必须切换到 Linux containers。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -6,7 +6,7 @@
 
 Supports **Qoder Global**, **Qoder CN**, **WorkBuddy Global**, **WorkBuddy CN**, and **Trae CN Solo**.
 
-Long-lived account runtimes, multi-account scheduling, one-command Docker start.
+Long-lived account runtimes, multi-account scheduling. Deploy with Docker; that is the supported install and update path.
 
 [![License](https://img.shields.io/github/license/caigee-cmd/cli2api)](LICENSE)
 [![LINUX DO](https://img.shields.io/badge/LINUX%20DO-community-ff6a00)](https://linux.do)
@@ -28,6 +28,8 @@ Long-lived account runtimes, multi-account scheduling, one-command Docker start.
 - **Cross-platform**: `linux/amd64` / `linux/arm64` images; macOS and Windows run them through Docker Desktop
 
 ## Quick start
+
+**Deploy with Docker.** Published images and console managed updates (pre-update snapshot, automatic rollback, next-version upgrades) are built around the single Compose container. Running the Go / Node sources directly is not on that update path.
 
 Requirements: Docker (Docker Desktop on macOS/Windows, Docker Engine + Compose on Linux) and a Qoder, WorkBuddy, or Trae account you control. On Windows, Docker Desktop must use Linux containers.
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -2,6 +2,11 @@
 
 ## 1. Start
 
+Docker Compose is the supported way to run CLI2API. Published images, the
+console System-page updater, pre-update SQLite snapshots, and automatic
+rollback all assume this single-container install. A source checkout of Go /
+Node is for development; it does not receive managed updates.
+
 The deployment is one container containing the Go control plane, provider
 adapters, Node runtime, pinned qodercli, and frontend. SQLite and account
 credentials persist in the `qoder-data` volume; per-account ephemeral runtimes


### PR DESCRIPTION
## Summary
- Tell readers and coding agents to deploy with Docker Compose, not a raw Go/Node checkout.
- Explain that published images and console managed updates (snapshot, rollback, next-version upgrades) assume the single-container install.

## Test plan
- [x] `python3 scripts/release-notes.py validate`
- [ ] Skim README.md / README_EN.md Quick start and deploy/README.md section 1