### PR TITLE
docs: freeze changelog for v0.2.46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### English
 
+### 中文
+
+## 0.2.46 - 2026-09-06
+
+### English
+
 - Recommend Docker Compose as the supported install and managed-update path in the README and deployment guide
 - Keep an account on a model route after a later catalog refresh omits an ID it already served, and report pool-wide quota cooldown as `insufficient_quota` instead of a generic rate limit
 


### PR DESCRIPTION
## Summary
- Freeze the published v0.2.46 notes out of `## Unreleased`.
- Release workflow could not push this freeze directly because `main` requires a pull request.

## Test plan
- [x] `python3 scripts/release-notes.py validate`
- [ ] CI on this PR