### PR TITLE
docs: freeze changelog for v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### English
 
+### 中文
+
+## 0.3.0 - 2026-09-06
+
+### English
+
 - Keep multi-turn conversations on the same account from the first user message by default, including image-only turns, without requiring `X-CLI2API-Session`
 - Cache `GET /api/models` for 5 minutes so the console catalog page does not re-hit WorkBuddy or Trae on every load; `?refresh=1` still fetches live. Overview stays uncached.
 


### PR DESCRIPTION
## Summary
- Move the v0.3.0 bilingual notes out of Unreleased after the published GitHub Release.
- The release workflow freeze job cannot push to protected main; this matches the 0.2.x follow-up PRs.

## Test plan
- [x] `python3 scripts/release-notes.py validate`
- [ ] CI on this PR