### PR TITLE
docs: freeze changelog for v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### English
 
+### 中文
+
+## 0.3.4 - 2026-09-07
+
+### English
+
 - Strip empty WorkBuddy chat-stream deltas so clients do not render a flood of blank thinking chunks
 
 ### 中文


### PR DESCRIPTION
## Summary
- Freeze the Unreleased bullets that shipped in [v0.3.4](https://github.com/caigee-cmd/cli2api/releases/tag/v0.3.4).
- Leave later work under Unreleased (none yet).

The Release workflow already published the tag, images, and updater assets. This PR only records those notes under the version heading; it does not re-run `release.yml`.