### PR TITLE
docs: freeze changelog for v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### English
 
+### 中文
+
+## 0.4.4 - 2026-09-10
+
+### English
+
 - Keep Qoder accounts routable when their base quota is exhausted but an available add-on or organization resource package still has credits, and show resource-package balance in the console
 
 ### 中文


### PR DESCRIPTION
## Summary

- freeze the published v0.4.4 bilingual release notes
- leave `Unreleased` ready for subsequent changes

## Test plan

- [x] `python3 scripts/release-notes.py validate`
- [x] No tokens, auth blobs, raw captures, or host details in the diff
