### PR TITLE
docs: freeze changelog for v0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### English
 
+### 中文
+
+## 0.4.5 - 2026-09-10
+
+### English
+
 - Open runtime log lines in a larger scrollable HeroUI detail modal, and align request-log details with the same roomy layout
 
 ### 中文


### PR DESCRIPTION
## Summary
- move the published v0.4.5 bilingual notes out of `Unreleased`
- keep `CHANGELOG.md` aligned with the published GitHub Release

## Verification
- `python3 scripts/release-notes.py validate`
- `python3 scripts/release-notes.py extract 0.4.5`
