### PR TITLE
docs: freeze changelog for v0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### English
 
+### 中文
+
+## 0.4.6 - 2026-09-10
+
+### English
+
 - Show missing Qoder account quota as loading or unavailable instead of incorrectly labeling it as requiring login
 
 ### 中文


### PR DESCRIPTION
## Summary
- Freeze the published `v0.4.6` bilingual release notes under the version heading.
- Leave `## Unreleased` empty for subsequent changes.

## Validation
- `python3 scripts/release-notes.py validate`
- `git diff --check`
