### PR TITLE
fix: answer CORS OPTIONS without an API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ Write each change in both `### English` and `### 中文` under `## Unreleased`.
 
 ### English
 
+- Answer CORS preflight `OPTIONS` without an API key so browser extensions can call `/v1`
 - Send WorkBuddy Deepseek V4.1 Flash thinking as official top-level reasoning fields so streamed thinking comes back
 - Show WorkBuddy catalog context budgets (default and optional window) on the model list without inventing a Trae Max switch
 
 ### 中文
 
+- CORS 预检 `OPTIONS` 不再要求 API Key，浏览器扩展可以调用 `/v1`
 - WorkBuddy 的 Deepseek V4.1 Flash 改为发送官方顶层思考字段，流式思考内容可以返回
 - 模型列表展示 WorkBuddy 目录里的默认和可选上下文窗口，不套用 Trae 的更大上下文开关
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ CLI2API 是本地网关：不提供账号、额度或官方 API 服务，不做�
 
 ## 安全
 
-默认只监听 `127.0.0.1:3010`；除 `/health` 和静态前端资源外，所有 API 与控制台数据接口均需要 API Key。不要提交 `.qoder`、Token、Cookie、登录 Blob 或原始抓包；凭证导出是显式敏感操作，请妥善保管导出文件。上游 API 或 CLI 更新可能导致兼容性变化，项目会固定并检查 qodercli 版本。发现安全问题请按 [SECURITY.md](SECURITY.md) 私下报告。
+默认只监听 `127.0.0.1:3010`；除 `/health`、静态前端资源和 CORS 预检 `OPTIONS` 外，所有 API 与控制台数据接口均需要 API Key。不要提交 `.qoder`、Token、Cookie、登录 Blob 或原始抓包；凭证导出是显式敏感操作，请妥善保管导出文件。上游 API 或 CLI 更新可能导致兼容性变化，项目会固定并检查 qodercli 版本。发现安全问题请按 [SECURITY.md](SECURITY.md) 私下报告。
 
 ## 社区
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -102,7 +102,7 @@ CLI2API is a local gateway: it does not provide accounts, quotas, or an official
 
 ## Security
 
-The service binds `127.0.0.1:3010` by default; all APIs and console data endpoints require the API key except `/health` and static frontend assets. Never commit `.qoder`, tokens, cookies, auth blobs, or raw captures; credential export is an explicit sensitive operation — protect exported files. Upstream API or CLI changes may affect compatibility; qodercli is pinned and checked. Please report security issues privately according to [SECURITY.md](SECURITY.md).
+The service binds `127.0.0.1:3010` by default; all APIs and console data endpoints require the API key except `/health`, static frontend assets, and CORS preflight `OPTIONS`. Never commit `.qoder`, tokens, cookies, auth blobs, or raw captures; credential export is an explicit sensitive operation — protect exported files. Upstream API or CLI changes may affect compatibility; qodercli is pinned and checked. Please report security issues privately according to [SECURITY.md](SECURITY.md).
 
 ## Community
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -124,7 +124,7 @@ The API key is generated once and stored in SQLite. There is no environment-vari
 | `POST` | `/v1/responses` | OpenAI Responses-compatible API |
 | `GET/POST/PATCH/DELETE` | `/api/*` | Console management API |
 
-All console and API routes except `/health` require the API key stored in SQLite.
+All console and API routes except `/health` and CORS preflight `OPTIONS` require the API key stored in SQLite.
 
 ## 7. Managed next-version update
 

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -30,6 +30,69 @@ func TestClassifyCanceledErrorDoesNotBecomeAuth(t *testing.T) {
 	}
 }
 
+func TestCORSPreflightSkipsAPIKey(t *testing.T) {
+	srv := New(config.Config{
+		Host:        "127.0.0.1",
+		Port:        3010,
+		ProxyAPIKey: "secret",
+		QoderHome:   t.TempDir(),
+	})
+	defer srv.Close()
+	h := srv.Handler()
+
+	for _, path := range []string{
+		"/v1/models",
+		"/v1/chat/completions",
+		"/v1/messages",
+		"/v1/responses",
+	} {
+		req := httptest.NewRequest(http.MethodOptions, path, nil)
+		req.Header.Set("Origin", "chrome-extension://abc")
+		req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+		req.Header.Set("Access-Control-Request-Headers", "authorization,content-type,x-api-key")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNoContent {
+			t.Fatalf("OPTIONS %s: got %d want 204 body=%s", path, rec.Code, rec.Body.String())
+		}
+		if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "chrome-extension://abc" {
+			t.Fatalf("OPTIONS %s allow-origin=%q", path, got)
+		}
+		allowHeaders := strings.ToLower(rec.Header().Get("Access-Control-Allow-Headers"))
+		if !strings.Contains(allowHeaders, "authorization") || !strings.Contains(allowHeaders, "content-type") {
+			t.Fatalf("OPTIONS %s allow-headers=%q", path, rec.Header().Get("Access-Control-Allow-Headers"))
+		}
+		if rec.Body.Len() != 0 {
+			t.Fatalf("OPTIONS %s body=%s", path, rec.Body.String())
+		}
+	}
+}
+
+func TestCORSHeadersOnUnauthorizedChat(t *testing.T) {
+	srv := New(config.Config{
+		Host:        "127.0.0.1",
+		Port:        3010,
+		ProxyAPIKey: "secret",
+		QoderHome:   t.TempDir(),
+	})
+	defer srv.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader([]byte("{}")))
+	req.Header.Set("Origin", "chrome-extension://abc")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("POST without key: got %d want 401 body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "chrome-extension://abc" {
+		t.Fatalf("allow-origin=%q", got)
+	}
+	if got := rec.Header().Get("Access-Control-Expose-Headers"); !strings.Contains(got, "X-Request-Id") {
+		t.Fatalf("expose-headers=%q", got)
+	}
+}
+
 func TestManagementRoutesRequireAPIKey(t *testing.T) {
 	srv := New(config.Config{
 		Host:        "127.0.0.1",

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -172,12 +172,48 @@ func generateAPIKey() (string, error) {
 
 func (s *Server) Handler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if applyCORS(w, r) {
+			return
+		}
 		if s.maintenance.Load() && blocksDuringUpdate(r.URL.Path) {
 			writeErr(w, http.StatusServiceUnavailable, "service_updating", "Service update in progress")
 			return
 		}
 		s.mux.ServeHTTP(w, r)
 	})
+}
+
+const (
+	corsAllowMethods  = "GET, POST, PUT, PATCH, DELETE, OPTIONS"
+	corsAllowHeaders  = "Authorization, Content-Type, x-api-key, X-CLI2API-Session, X-Qoder-Account"
+	corsExposeHeaders = "X-Request-Id, X-Qoder-Account, X-CLI2API-Account, X-CLI2API-Provider, Retry-After"
+)
+
+func applyCORS(w http.ResponseWriter, r *http.Request) bool {
+	origin := strings.TrimSpace(r.Header.Get("Origin"))
+	if origin == "" && r.Method != http.MethodOptions {
+		return false
+	}
+	allowOrigin := origin
+	if allowOrigin == "" {
+		allowOrigin = "*"
+	}
+	header := w.Header()
+	header.Set("Access-Control-Allow-Origin", allowOrigin)
+	header.Set("Access-Control-Allow-Methods", corsAllowMethods)
+	allowHeaders := strings.TrimSpace(r.Header.Get("Access-Control-Request-Headers"))
+	if allowHeaders == "" {
+		allowHeaders = corsAllowHeaders
+	}
+	header.Set("Access-Control-Allow-Headers", allowHeaders)
+	header.Set("Access-Control-Expose-Headers", corsExposeHeaders)
+	header.Set("Access-Control-Max-Age", "86400")
+	header.Add("Vary", "Origin")
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return true
+	}
+	return false
 }
 
 func (s *Server) Close() error {


### PR DESCRIPTION
## Summary
- Serve CORS preflight `OPTIONS` with `204` before API-key auth so browser extensions can call `/v1` ([#145](https://github.com/caigee-cmd/cli2api/issues/145)).
- Reflect `Origin` and allow `Authorization`, `Content-Type`, `x-api-key`, `X-CLI2API-Session`, and `X-Qoder-Account`.
- Keep GET/POST authenticated; unauthorized chat still returns `401` with CORS headers so the client can read the error.

## Test plan
- [x] `go test ./internal/api/ -count=1 -run 'TestCORS|TestManagementRoutesRequireAPIKey|TestNamedAPIKeyCannotManage'`
- [x] Confirm an extension `OPTIONS /v1/chat/completions` no longer gets `401`
- [x] Confirm `POST /v1/chat/completions` without a key is still `401`

Closes #145